### PR TITLE
Remove the double touch rule

### DIFF
--- a/chapters/appendix.adoc
+++ b/chapters/appendix.adoc
@@ -5,9 +5,6 @@ When the match is <<Stopping The Game, stopped>>, the ball is considered *out of
 
 When the match is <<Resuming The Game, resumed>>, the ball is considered *in play* until the next stoppage occurs. The match is resumed when <<Force Start, force start>> has been issued or the ball moved at least 0.05 meters following a <<Kick-Off, kick-off>>, <<Direct Free Kick, direct free kick>>, <<Indirect Free Kick, indirect free kick>> or <<Penalty Kick, penalty kick>>.
 
-NOTE: see <<Double Touch, double touch>> for the rationale of the 0.05 meter distance
-
-
 === Ball Manipulation
 Shooting and <<Dribbling Device, dribbling>> is considered as manipulating the ball, the ball accidentally bouncing off the hull is not.
 
@@ -61,7 +58,6 @@ Chapter <<Offenses>>, section <<Minor Offenses>>:
 
 | <<Aimless Kick [small]#(_division B only_)#, Aimless Kick>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Indirect Free Kick>> | icon:check[role="green"]
 | <<Lack Of Progress>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Indirect Free Kick>> | icon:check[role="green"]
-| <<Double Touch>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Indirect Free Kick>> | icon:check[role="green"]
 | <<Attacker In Defense Area>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Indirect Free Kick>> | icon:check[role="green"]
 | <<Attacker Touches Robot In Opponent Defense Area>> skipped | <<Ball In And Out Of Play, ball in play>> | no command | icon:check[role="green"] (<<Advantage Rule>>)
 | <<Excessive Dribbling>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Indirect Free Kick>> | icon:check[role="green"]

--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -20,13 +20,6 @@ NOTE: If both teams are allowed to manipulate the ball, and thus no team is at f
 
 NOTE: If both teams are clearly unable to bring the ball <<Ball In And Out Of Play, into play>> without violating the rules, the referee may issue a <<Force Start, force start>> command instead of an <<Indirect Free Kick, indirect free kick>> for the other team.
 
-==== Double Touch
-When the ball is brought <<Ball In And Out Of Play, into play>> following a <<Kick-Off, kick-off>>, <<Direct Free Kick, direct free kick>>, <<Indirect Free Kick, indirect free kick>> or <<Penalty Kick, penalty kick>>, the kicker is not allowed to touch the ball until it has been touched by another robot or the game has been stopped.
-
-The ball must have moved at least 0.05 meters to be considered as <<Ball In And Out Of Play, in play>>.
-
-NOTE: It is understood that the ball may be bumped by the robot multiple times over a short distance while the kick is being taken. This is why a distance of 0.05 meters is used to decide whether a robot violates this rule or not. Remaining in contact with the ball for more than 0.05 meters also counts as double touch, even though technically the robot only touched the ball once.
-
 ==== Attacker In Defense Area
 A robot must not touch the ball while being partially or fully inside the opponent <<Defense Area, defense area>>.
 

--- a/chapters/refereecommands.adoc
+++ b/chapters/refereecommands.adoc
@@ -86,8 +86,6 @@ When the kick-off command is issued, all robots have to move to their own half o
 
 When the <<Normal Start, normal start>> command is issued, the kicker is allowed to shoot the ball. A goal may be scored directly from the kick-off.
 
-When the ball is <<Ball In And Out Of Play, in play>>, the kicker may not touch the ball until it has been touched by another robot or the game has been stopped (see <<Double Touch, double touch>>). Also, the restrictions regarding the robot positions are lifted.
-
 .Usage
 Both half times as well as both overtime periods (if needed) start with a kick-off. Chapter <<Match Preparation>> describes how to determine the attacking team.
 
@@ -99,10 +97,10 @@ The ball placement position for a free kick depends on the event that led to the
 
 When the direct free kick command is issued, robots of the attacking team are allowed to approach the ball while robots of the defending team still have to stay at least 0.5 meters distance away from the ball (the same distance as in stop). One robot of the attacking team is allowed to shoot the ball. This robot will be referred to as the kicker. A goal may be scored directly from the direct free kick.
 
-When the ball is <<Ball In And Out Of Play, in play>>, the kicker may not touch the ball until it has been touched by another robot or the game has been stopped (see <<Double Touch, double touch>>). Also, the restrictions regarding the robot positions are lifted.
+When the ball is <<Ball In And Out Of Play, in play>>, the restrictions regarding the robot positions are lifted.
 
 .Usage
-Direct free kicks are used to restart the game after a <<Fouls, foul>> has occured. Additionally, <<Goal Kick, goal kicks>> and <<Corner Kick, corner kicks>> are mapped to direct free kicks.
+Direct free kicks are used to restart the game after a <<Fouls, foul>> has occurred. Additionally, <<Goal Kick, goal kicks>> and <<Corner Kick, corner kicks>> are mapped to direct free kicks.
 
 ==== Indirect Free Kick
 .Definition
@@ -115,7 +113,7 @@ NOTE: Scoring a goal from an indirect free kick does not require more than one a
 NOTE: In association football, it is sufficient if any player (including the keeper) touches the ball before it enters the goal. To discourage the teams to shoot directly at the goal and hope that the keeper touches it, the rules of the Small Size League require a second touch of an attacking robot.
 
 .Usage
-Indirect free kicks are used to restart the game after a <<Minor Offenses, minor offense>> has occured. Additionally, <<Throw-In, throw-ins>> are mapped to indirect free kicks.
+Indirect free kicks are used to restart the game after a <<Minor Offenses, minor offense>> has occurred. Additionally, <<Throw-In, throw-ins>> are mapped to indirect free kicks.
 
 ==== Force Start
 .Definition
@@ -134,7 +132,7 @@ When the penalty command is issued, one attacking robot is allowed to approach b
 
 When the <<Normal Start, normal start>> command is issued, the kicker is allowed to shoot the ball. A goal may be scored directly from the penalty kick.
 
-When the ball is <<Ball In And Out Of Play, in play>>, the kicker may not touch the ball until it has been touched by another robot or the game has been stopped (see <<Double Touch, double touch>>). Also, the restrictions regarding the robot positions are lifted.
+When the ball is <<Ball In And Out Of Play, in play>>, the restrictions regarding the robot positions are lifted.
 
 Additional time is allowed for a penalty kick to be taken at the end of each half or at the end of periods of overtime.
 


### PR DESCRIPTION
From the Rule Change proposal:

> After free kicks and kickoffs, robots are not allowed to touch the ball a second time until another robot has touched the ball.
> On the road to reducing stoppages, we propose to remove this constraint.
> Double touch in the SSL often happens due to imprecision, not by intention. When the ball is moved (by 0.05m), it is in play anyway, so all robots can touch it.
> We want to encourage teams to work on dribbling balls (dribbling in the sense of small kicks, the 1m dribbling rule still applies) and the double touch rule rather counteracts this.
