### PR TITLE
Ball going out of field (due to chip kick) (both Div)

### DIFF
--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -107,6 +107,9 @@ If a robot other than the keeper touches the ball while being partially inside i
 
 If a robot other than the keeper touches the ball while being entirely inside its own defense area, the game is stopped and a <<Penalty Kick, penalty kick>> is awarded to the other team. The foul counter is not increased.
 
+==== Boundary Crossing
+A robot must not kick the ball over the field boundary such that the ball leaves the field.
+
 
 === Unsporting Behavior
 Unsporting behavior can lead to <<Yellow Card, yellow cards>>, <<Red Card, red cards>>, <<Penalty Kick, penalty kicks>>, a <<Forced Forfeit, forced forfeit>> or a <<Disqualification, disqualification>>. The human <<Referee, referee>> chooses an appropriate sanction, depending on the severity of the offense.


### PR DESCRIPTION
From the Rule Change proposal:

> Even with walls, the ball can still leave the field, if flying over the wall.
> Teams should be encouraged to keep the ball inside the field, so there should be an adequate penalty for chipping the ball out. 
> 
> If a teams chips the ball out, the foul counter of this team will be incremented.
> 
> If playing without walls, the game is restarted as if the ball left the field normally.
> If playing with walls, the game is restarted with a free kick according to the current rules.
> 
> For simplicity, this change is not limited to games with walls.
