### PR TITLE
Add rule for changing keeper Id

### DIFF
--- a/chapters/gamestructure.adoc
+++ b/chapters/gamestructure.adoc
@@ -97,7 +97,9 @@ The <<Referee, referee>> tosses a coin with both <<Robot Handler, robot handlers
 ==== Choosing Keeper Id
 The <<Referee, referee>> asks both <<Robot Handler, robot handlers>> which robot they will use as the keeper and forwards this information to the <<Game Controller Operator, game controller operator>>.
 
-The keeper Id can also be changed during game play, this can be done automatically by using the <<Game Controller, game controller>> network interface or manually, in this case, the <<Game Controller Operator, game controller operator>> is responsible for checking if the ball is in a valid position and making the change.
+The keeper id can also be changed during game play. This can be done automatically by using the <<Game Controller, game controller>> network interface or by asking the <<Game Controller Operator, game controller operator>> to change it in the <<Game Controller, game controller>>. The <<Game Controller Operator, game controller operator>> must not change the keeper id until the ball is at a valid position.
+
+Teams can automatically change their keeper id when the ball is on the opponent's half by using the <<Game Controller, game controller>> network interface.
 
 NOTE: If a team does not want to use a keeper, it may select the id of a robot that is not on the field.
 

--- a/chapters/gamestructure.adoc
+++ b/chapters/gamestructure.adoc
@@ -97,6 +97,8 @@ The <<Referee, referee>> tosses a coin with both <<Robot Handler, robot handlers
 ==== Choosing Keeper Id
 The <<Referee, referee>> asks both <<Robot Handler, robot handlers>> which robot they will use as the keeper and forwards this information to the <<Game Controller Operator, game controller operator>>.
 
+The keeper Id can also be changed during game play, this can be done automatically by using the <<Game Controller, game controller>> network interface or manually via the <<Game Controller Operator, game controller operator>>.
+
 NOTE: If a team does not want to use a keeper, it may select the id of a robot that is not on the field.
 
 === Game Stages

--- a/chapters/gamestructure.adoc
+++ b/chapters/gamestructure.adoc
@@ -97,7 +97,7 @@ The <<Referee, referee>> tosses a coin with both <<Robot Handler, robot handlers
 ==== Choosing Keeper Id
 The <<Referee, referee>> asks both <<Robot Handler, robot handlers>> which robot they will use as the keeper and forwards this information to the <<Game Controller Operator, game controller operator>>.
 
-. If the ball is <<Ball In And Out Of Play, in play>>, the keeper id can only be changed if it is on the opponent's half. There is an automatic and a manual procedure, which are defined below, respectively:
+. If the ball is <<Ball In And Out Of Play, in play>>, the keeper id can only be changed if the ball is in the opponent's half. There is an automatic and a manual procedure, which are defined below, respectively:
 .. Done automatically by using the <<Game Controller, game controller>> network interface
 .. Done by asking the <<Game Controller Operator, game controller operator>> to change it in the <<Game Controller, game controller>>. The <<Game Controller Operator, game controller operator>> must not change the keeper id until the ball is at a valid position.
 

--- a/chapters/gamestructure.adoc
+++ b/chapters/gamestructure.adoc
@@ -97,7 +97,7 @@ The <<Referee, referee>> tosses a coin with both <<Robot Handler, robot handlers
 ==== Choosing Keeper Id
 The <<Referee, referee>> asks both <<Robot Handler, robot handlers>> which robot they will use as the keeper and forwards this information to the <<Game Controller Operator, game controller operator>>.
 
-The keeper Id can also be changed during game play, this can be done automatically by using the <<Game Controller, game controller>> network interface or manually via the <<Game Controller Operator, game controller operator>>.
+The keeper Id can also be changed during game play, this can be done automatically by using the <<Game Controller, game controller>> network interface or manually, in this case, the <<Game Controller Operator, game controller operator>> is responsible for checking if the ball is in a valid position and making the change.
 
 NOTE: If a team does not want to use a keeper, it may select the id of a robot that is not on the field.
 

--- a/chapters/gamestructure.adoc
+++ b/chapters/gamestructure.adoc
@@ -97,9 +97,11 @@ The <<Referee, referee>> tosses a coin with both <<Robot Handler, robot handlers
 ==== Choosing Keeper Id
 The <<Referee, referee>> asks both <<Robot Handler, robot handlers>> which robot they will use as the keeper and forwards this information to the <<Game Controller Operator, game controller operator>>.
 
-The keeper id can also be changed during game play. This can be done automatically by using the <<Game Controller, game controller>> network interface or by asking the <<Game Controller Operator, game controller operator>> to change it in the <<Game Controller, game controller>>. The <<Game Controller Operator, game controller operator>> must not change the keeper id until the ball is at a valid position.
+. If the ball is <<Ball In And Out Of Play, in play>>, the keeper id can only be changed if it is on the opponent's half. There is an automatic and a manual procedure, which are defined below, respectively:
+.. Done automatically by using the <<Game Controller, game controller>> network interface
+.. Done by asking the <<Game Controller Operator, game controller operator>> to change it in the <<Game Controller, game controller>>. The <<Game Controller Operator, game controller operator>> must not change the keeper id until the ball is at a valid position.
 
-Teams can automatically change their keeper id when the ball is on the opponent's half by using the <<Game Controller, game controller>> network interface.
+NOTE: Teams should only ask for a change once the requirements are met. The <<Game Controller Operator, game controller operator>> is responsible for complying to the rules.
 
 NOTE: If a team does not want to use a keeper, it may select the id of a robot that is not on the field.
 

--- a/chapters/gamestructure.adoc
+++ b/chapters/gamestructure.adoc
@@ -97,9 +97,10 @@ The <<Referee, referee>> tosses a coin with both <<Robot Handler, robot handlers
 ==== Choosing Keeper Id
 The <<Referee, referee>> asks both <<Robot Handler, robot handlers>> which robot they will use as the keeper and forwards this information to the <<Game Controller Operator, game controller operator>>.
 
-. If the ball is <<Ball In And Out Of Play, in play>>, the keeper id can only be changed if the ball is in the opponent's half. There is an automatic and a manual procedure, which are defined below, respectively:
-.. Done automatically by using the <<Game Controller, game controller>> network interface
-.. Done by asking the <<Game Controller Operator, game controller operator>> to change it in the <<Game Controller, game controller>>. The <<Game Controller Operator, game controller operator>> must not change the keeper id until the ball is at a valid position.
+The keeper id can be changed anytime during the game if the ball is either <<Ball In And Out Of Play, out of play>> or in the opponent's field half by:
+
+. Using the <<Game Controller, game controller>> network interface
+. Asking the <<Game Controller Operator, game controller operator>> to change it in the <<Game Controller, game controller>>. The <<Game Controller Operator, game controller operator>> must not change the keeper id until the ball is at a valid position.
 
 NOTE: Teams should only ask for a change once the requirements are met. The <<Game Controller Operator, game controller operator>> is responsible for complying to the rules.
 

--- a/chapters/playingenvironment.adoc
+++ b/chapters/playingenvironment.adoc
@@ -82,7 +82,7 @@ Besides the shared vision equipment, teams are not allowed to mount their own ca
 A game is controlled by the community-maintained ssl-game-controller (https://github.com/RoboCup-SSL/ssl-game-controller).
 It is operated by the <<Game Controller Operator, game controller operator>>. The software translates decisions of the <<Referee, referee>> and the <<Automatic Referee, automatic referee>> into Ethernet communication signals that are broadcast to the network. It maintains the state of the game, tracks all events and acts as a proxy between all participating parties in the game.
 
-The game-controller has a network interface for the playing teams. They can automatically change their keeper id when the ball is <<Ball In And Out Of Play, out of play>>, they can signal a robot substitution intent for the next opportunity and they can reply to requests of the <<Advantage Rule, advantage rule>>.
+The game-controller has a network interface for the playing teams. They can automatically change their keeper id when the ball is on the opponent's half, they can signal a robot substitution intent for the next opportunity and they can reply to requests of the <<Advantage Rule, advantage rule>>.
 
 ==== Automatic Referee
 One or more automatic referee applications can supervise a game and report <<Offenses, offenses>> to the <<Game Controller, game controller>>.

--- a/chapters/playingenvironment.adoc
+++ b/chapters/playingenvironment.adoc
@@ -82,7 +82,7 @@ Besides the shared vision equipment, teams are not allowed to mount their own ca
 A game is controlled by the community-maintained ssl-game-controller (https://github.com/RoboCup-SSL/ssl-game-controller).
 It is operated by the <<Game Controller Operator, game controller operator>>. The software translates decisions of the <<Referee, referee>> and the <<Automatic Referee, automatic referee>> into Ethernet communication signals that are broadcast to the network. It maintains the state of the game, tracks all events and acts as a proxy between all participating parties in the game.
 
-The game-controller has a network interface for the playing teams. They can automatically change their keeper id when the ball is on the opponent's half, they can signal a robot substitution intent for the next opportunity and they can reply to requests of the <<Advantage Rule, advantage rule>>.
+The game-controller has a network interface for the playing teams. They can automatically <<Choosing Keeper Id, change their keeper id>>, they can signal a robot substitution intent for the next opportunity and they can reply to requests of the <<Advantage Rule, advantage rule>>.
 
 ==== Automatic Referee
 One or more automatic referee applications can supervise a game and report <<Offenses, offenses>> to the <<Game Controller, game controller>>.


### PR DESCRIPTION
From the Rule change proposal:

> The keeper ID can be automatically changed with the team protocol which was introduced in 2019, but teams could only change the keeper during STOP.
> This is an unnecessary limitation. With reduced number of stops, this becomes even more important.
> 
> We propose to allow changing the keeper id, as long as the ball is on the opponent's half. This applies to the team protocol as well as to the manual change via the game controller operator.
