### PR TITLE
Vision dropouts

### DIFF
--- a/chapters/refereecommands.adoc
+++ b/chapters/refereecommands.adoc
@@ -17,7 +17,7 @@ When the halt command is issued, no robot is allowed to move or <<Ball Manipulat
 There is a grace period of 2 seconds for the robots to brake.
 
 .Usage
-The halt command allows the referee to interrupt the game immediately whenever an emergency occurs (for example when a robot gets out of contol). It is also used for <<Robot Substitution, robot substitution>>. Additionally, the referee is free to issue the halt command at will.
+The halt command allows the referee to interrupt the game immediately whenever an emergency occurs (for example when a robot gets out of control). It is also used for <<Robot Substitution, robot substitution>>. Additionally, the referee is free to issue the halt command at will.
 
 Regarding the vision system, the game will be immediately halted in case of catastrophic failures, which includes:
 
@@ -28,12 +28,14 @@ Regarding the vision system, the game will be immediately halted in case of cata
 
 The game is continued in case of:
 
-. The ball is detected at least every 0.2s while not being covered by some robot or shadow;
-. All robots on the field are detected at least every 0.5s;
+. The ball is detected at least every 0.2 seconds while not being covered by some robot or shadow;
+. All robots on the field are detected at least every 0.5 seconds;
+
+In case the robot or ball detection gets worse than the previously defined threshold, the game may be halted. There won't be any tool that guarantees that the game will be halted in case those thresholds are violated.
  
 NOTE: Teams are responsible for validating the vision calibration before the game starts.
 
-To help newcoming teams, link:https://github.com/RoboCup-SSL/ssl-autorefs[TIGERs Autoref] broadcasts filtered balls and robots through the link:https://ssl.robocup.org/league-software/[ssl-vision-tracker-protocol]
+To help new teams, link:https://github.com/RoboCup-SSL/ssl-autorefs[TIGERs Autoref] broadcasts filtered balls and robots through the link:https://ssl.robocup.org/league-software/[ssl-vision-tracker-protocol]
 
 The halt command is always followed up by stop.
 

--- a/chapters/refereecommands.adoc
+++ b/chapters/refereecommands.adoc
@@ -17,8 +17,23 @@ When the halt command is issued, no robot is allowed to move or <<Ball Manipulat
 There is a grace period of 2 seconds for the robots to brake.
 
 .Usage
-The halt command allows the referee to interrupt the game immediately whenever an emergency occurs (for example when a robot gets out of contol). It is
-also used to recalibrate the vision software during a game if the vision expert considers it necessary and the referee agrees and for <<Robot Substitution, robot substitution>>. Additionally, the referee is free to issue the halt command at will.
+The halt command allows the referee to interrupt the game immediately whenever an emergency occurs (for example when a robot gets out of contol). It is also used for <<Robot Substitution, robot substitution>>. Additionally, the referee is free to issue the halt command at will.
+
+Regarding the vision system, the game will be immediately halted in case of catastrophic failures, which includes:
+
+. Camera failures;
+. SSL-Vision crash;
+. Network failures;
+. Anything that causes a significant drop in the frame rate of the data;
+
+The game is continued in case of:
+
+. The ball is detected at least every 0.2s while not being covered by some robot or shadow;
+. All robots on the field are detected at least every 0.5s;
+ 
+NOTE: Teams are responsible for validating the vision calibration before the game starts.
+
+To help newcoming teams, link:https://github.com/RoboCup-SSL/ssl-autorefs[TIGERs Autoref] broadcasts filtered balls and robots through the link:https://ssl.robocup.org/league-software/[ssl-vision-tracker-protocol]
 
 The halt command is always followed up by stop.
 

--- a/chapters/refereecommands.adoc
+++ b/chapters/refereecommands.adoc
@@ -17,8 +17,20 @@ When the halt command is issued, no robot is allowed to move or <<Ball Manipulat
 There is a grace period of 2 seconds for the robots to brake.
 
 .Usage
-The halt command allows the referee to interrupt the game immediately whenever an emergency occurs (for example when a robot gets out of contol). It is
-also used to recalibrate the vision software during a game if the vision expert considers it necessary and the referee agrees and for <<Robot Substitution, robot substitution>>. Additionally, the referee is free to issue the halt command at will.
+The halt command allows the referee to interrupt the game immediately whenever an emergency occurs (for example when a robot gets out of contol). It is also used for <<Robot Substitution, robot substitution>>. Additionally, the referee is free to issue the halt command at will.
+
+Regarding the vision system, the game should only be halted in case of catastrophic failures of ssl-vision, which includes:
+
+. Camera failures;
+. SSL-Vision crash;
+. Any robot or ball not being detected at all.
+
+Teams must be able to deal with:
+
+. Robots and ball flickering;
+. Robots and ball not being detected for short periods of time, e.g. less than 1 second.
+
+To help newcoming teams, link:https://github.com/RoboCup-SSL/ssl-autorefs[TIGERs Autoref] broadcasts filtered balls and robots through the link:https://ssl.robocup.org/league-software/[ssl-vision-tracker-protocol]
 
 The halt command is always followed up by stop.
 

--- a/chapters/refereecommands.adoc
+++ b/chapters/refereecommands.adoc
@@ -31,7 +31,11 @@ The game is continued in case of:
 . The ball is detected at least every 0.2 seconds while not being covered by some robot or shadow;
 . All robots on the field are detected at least every 0.5 seconds;
 
-In case the robot or ball detection gets worse than the previously defined threshold, the game may be halted. There won't be any tool that guarantees that the game will be halted in case those thresholds are violated.
+In case the robot or ball detection gets worse than the previously defined threshold, the game may be halted.
+
+The <<Vision Expert, vision expert>> may monitor a link:https://github.com/RoboCup-SSL/ssl-quality-inspector[quality inspecting tool] that both teams agree with and signal issues with the vision system to the referee. Only tools that are run on official league computers are allowed for vision quality checks.
+
+NOTE: In order to avoid interruptions, only officially proven issues should lead to game stoppages.
  
 NOTE: Teams are responsible for validating the vision calibration before the game starts.
 


### PR DESCRIPTION
From the Rule proposal:

> Robot detections from ssl-vision are not always reliable. We work on improving ssl-vision (new cameras, april-tags), but we cannot guarantee that detections will be stable at all times. Teams have to deal with vanishing robots as well.
> 
> We propose to stop the game only for catastrophic failures of ssl-vision, like camera failures. Teams have to make sure that the detections are good during their preparation time before the match starts and the game will not be stopped for vision problems afterwards.
> 
> We are aware that new teams may not focus on a good filter in the beginning, so they might have more difficulties with bad vision. There are several open-source filters available, though.
> We’d like to establish a protobuf message that includes filtered vision data including velocities. An initial producer of this new message could be the autoRefs, which have filters and are open-source already.
> We will not guarantee the availability of such a software, but we will do our best to make it happen.

This change applies to both divisions