### PR TITLE
Robot interchange during game play (Both Div)

### DIFF
--- a/chapters/gamestructure.adoc
+++ b/chapters/gamestructure.adoc
@@ -72,7 +72,7 @@ Before the start of the match, every team has to designate one robot handler. Th
 .Duties
 * The robot handler helps <<Match Preparation, preparing the match>>.
 * The robot handler asks the referee for <<Timeouts, timeouts>> if necessary.
-* The robot handler can substitute a robot during game play, if it is at the halfway line (Division A only), <<Robot Substitution, substitutes the robot>>.
+* The robot handler can substitute a robot during game play, <<Robot Substitution, substitutes the robot>>.
 * The robot handler asks the referee for the permission to substitute a robot in the next stoppage and, if the referee agrees, <<Robot Substitution, substitutes the robot>>.
 * The robot handler voices concerns of the team (for example network issues or vision problems).
 

--- a/chapters/gamestructure.adoc
+++ b/chapters/gamestructure.adoc
@@ -72,7 +72,7 @@ Before the start of the match, every team has to designate one robot handler. Th
 .Duties
 * The robot handler helps <<Match Preparation, preparing the match>>.
 * The robot handler asks the referee for <<Timeouts, timeouts>> if necessary.
-* The robot handler can substitute a robot during game play, <<Robot Substitution, substitutes the robot>>.
+* The robot handler can <<Robot Substitution, substitute a robot during game play>>.
 * The robot handler asks the referee for the permission to substitute a robot in the next stoppage and, if the referee agrees, <<Robot Substitution, substitutes the robot>>.
 * The robot handler voices concerns of the team (for example network issues or vision problems).
 

--- a/chapters/gamestructure.adoc
+++ b/chapters/gamestructure.adoc
@@ -72,7 +72,7 @@ Before the start of the match, every team has to designate one robot handler. Th
 .Duties
 * The robot handler helps <<Match Preparation, preparing the match>>.
 * The robot handler asks the referee for <<Timeouts, timeouts>> if necessary.
-* The robot handler can substitue a robot during game play, if it is at the midline (Division A only), <<Robot Substitution, substitutes the robot>>.
+* The robot handler can substitute a robot during game play, if it is at the halfway line (Division A only), <<Robot Substitution, substitutes the robot>>.
 * The robot handler asks the referee for the permission to substitute a robot in the next stoppage and, if the referee agrees, <<Robot Substitution, substitutes the robot>>.
 * The robot handler voices concerns of the team (for example network issues or vision problems).
 

--- a/chapters/gamestructure.adoc
+++ b/chapters/gamestructure.adoc
@@ -72,6 +72,7 @@ Before the start of the match, every team has to designate one robot handler. Th
 .Duties
 * The robot handler helps <<Match Preparation, preparing the match>>.
 * The robot handler asks the referee for <<Timeouts, timeouts>> if necessary.
+* The robot handler can substitue a robot during game play, if it is at the midline (Division A only), <<Robot Substitution, substitutes the robot>>.
 * The robot handler asks the referee for the permission to substitute a robot in the next stoppage and, if the referee agrees, <<Robot Substitution, substitutes the robot>>.
 * The robot handler voices concerns of the team (for example network issues or vision problems).
 

--- a/chapters/playingenvironment.adoc
+++ b/chapters/playingenvironment.adoc
@@ -24,7 +24,7 @@ image::double-size-field.png[]
 ==== Field Surface
 The playing surface is green felt mat or carpet. The floor under the carpet is level, flat, and hard.
 
-The field surface will continue for 0.7 meters beyond the <<Field Lines, field lines>> on all sides. The outer 0.4 meters of this runoff area, separated from the robot area by a 0.1 meters tall wall, is used as a designated walking area for the <<Referee, referee>> and the <<Assistant Referee, assistant referee>>.
+The field surface will continue for 0.7 meters beyond the <<Field Lines, field lines>> on all sides. The outer 0.4 meters of this runoff area, separated from the robot area by a 0.1 meters tall wall, is used as a designated walking area for the <<Referee, referee>> and the <<Assistant Referee, assistant referee>>. The remaining 0.3 meters are the field margins.
 
 
 ==== Field Markings

--- a/chapters/substitution.adoc
+++ b/chapters/substitution.adoc
@@ -2,18 +2,22 @@
 .Definition
 Robots are substituted by the <<Robot Handler, robot handler>> of the respective team. No other team member is allowed to take robots out or put robots in.
 
-. The <<Robot Handler, robot handler>> must preferably not wear colors that may interfere with the vision system.
-.. If non-stop robot interchange is allowed (Division A), the <<Robot Handler, robot handler>> should preffer using long sleeves.
+. Robot substitution during game play - Division A only:
+.. The <<Robot Handler, robot handler>> should prefer to use long sleeves and colors that won't interfere with the vision system.
+.. A <<Robot Handler, robot handler>> who's team is marked for robot substitution performs at least one of the following operations in the given order.
+... Put robots in during game play. If the ball is at least 2 meters away from the mid line, the robot can be placed in it without notifying the <<Referee, referee>>.
+... Take robots out during game play (Division A only). If a robot is at the mid line and the ball is at least 2 meters away from the mid line, the robot can be removed without notifying the <<Referee, referee>>.
 
-. A <<Robot Handler, robot handler>> who's team is marked for robot substitution performs at least one of the following operations in the given order.
-.. Put robots in. The maximum allowed number of robots of the team on the field must not be exceeded.
-.. Put robots in during game play (Division A only). If the ball is at least 2 meters away from the midline, the robot can be placed in it without notifying the <<Referee, referee>>.
-.. Take robots out. If a robot that is taken out is closer than 1 meter to the intersection of the halfway line with one of the touch lines, another robot can be put in right away. Otherwise the robot handler has to wait until the next substitution opportunity.
-.. Take robots out during game play (Division A only). If a robot is at the midline and the ball is at least 2 meters away from the midline, the robot can be removed without notifying the <<Referee, referee>>.
+. Robot substitution on next stoppage - Both Divisions:
+.. A <<Robot Handler, robot handler>> who's team is marked for robot substitution performs at least one of the following operations in the given order.
+... Put robots in. The maximum allowed number of robots of the team on the field must not be exceeded.
+... Take robots out. If a robot that is taken out is closer than 1 meter to the intersection of the halfway line with one of the touch lines, another robot can be put in right away. Otherwise the robot handler has to wait until the next substitution opportunity.
+... The <<Robot Handler, robot handler>> informs the <<Referee, referee>> when done.
+... When both teams finished the robot substitution, the <<Referee, referee>> informs the <<Game Controller Operator, game controller operator>>.
+... The <<Game Controller Operator, game controller operator>> performs a <<Stop, stop>> followed by continuing the game.
+
 . If one of the robots taken out is the keeper, the <<Robot Handler, robot handler>> tells the <<Game Controller Operator, game controller operator>> the id of the robot that takes over the keeper role.
-. The <<Robot Handler, robot handler>> informs the <<Referee, referee>> when done.
-. When both teams finished the robot substitution, the <<Referee, referee>> informs the <<Game Controller Operator, game controller operator>>.
-. The <<Game Controller Operator, game controller operator>> performs a <<Stop, stop>> followed by continuing the game.
+
 
 .Usage
 Robots can be substituted for any reason. There is no limit on the number of substitutions.
@@ -23,6 +27,7 @@ A robot substitution intent can be made by:
 . A <<Robot Handler, robot handler>> by informing the <<Game Controller Operator, game controller operator>> who in turn enters the intent into the <<Game Controller, game controller>>.
 . A team software by sending a request to the <<Game Controller, game controller>>.
 . The <<Game Controller, game controller>> itself if a team exceeds the maximum number of robots (for example after a team receives a <<Yellow Card, yellow>> or <<Red Card, red card>>).
+. *(Division A only)* If a robot needs to be taken out and it is not in the mid line, a timeout needs to be taken in order for the team to remove the robot from the field. If a team is out of timeouts, it will still be able to take the robot out, however, it will not be able to use any remaining timeout time, the robot must be removed from the field as fast as possible.
 
 If the game was halted due to a substitution intent by a team, at least one substitution (taking a robot out or putting one in) must be performed by this team. A substitution intent can be revoked unless the game was not already halted for substitution.
 

--- a/chapters/substitution.adoc
+++ b/chapters/substitution.adoc
@@ -4,12 +4,15 @@ Robots are substituted by the <<Robot Handler, robot handler>> of the respective
 
 . Robot substitution during game play:
 .. The <<Robot Handler, robot handler>> should prefer to use long sleeves and colors that won't interfere with the vision system.
-.. A <<Robot Handler, robot handler>> who's team is marked for robot substitution performs at least one of the following operations in the given order.
-... Put robots in. If the ball is at least 2 meters away from the halfway line, the robot can be placed on the intersection of the halfway line with any touch line without notifying the <<Referee, referee>>.
-... Take robots out. If a robot is at the intersection of the halfway line with any touch line and the ball is at least 2 meters away from the halfway line, the robot can be removed without notifying the <<Referee, referee>>.
+.. A robot can only be substituted while obeying the following specifications:
+... Is at least on top of any touch line, if possible the robot can also be placed beyond the field boundaries
+... At a distance from the halfway line that must not exceed 30 centimeters
+.. A <<Robot Handler, robot handler>> who's team is marked for robot substitution performs the following operations.
+... Put robots in. If the ball is at least 2 meters away from the halfway line, the robot can be substituted without notifying the <<Referee, referee>>.
+... Take robots out. If the robot is placed at the previous specified position and the ball is at least 2 meters away from the halfway line, the robot can be removed without notifying the <<Referee, referee>>.
 
 . Robot substitution on next stoppage:
-.. A <<Robot Handler, robot handler>> who's team is marked for robot substitution performs at least one of the following operations in the given order.
+.. A <<Robot Handler, robot handler>> who's team is marked for robot substitution performs the following operations.
 ... Put robots in. The maximum allowed number of robots of the team on the field must not be exceeded.
 ... Take robots out. If a robot that is taken out is closer than 1 meter to the intersection of the halfway line with one of the touch lines, another robot can be put in right away. Otherwise the robot handler has to wait until the next substitution opportunity.
 ... The <<Robot Handler, robot handler>> informs the <<Referee, referee>> when done.

--- a/chapters/substitution.adoc
+++ b/chapters/substitution.adoc
@@ -6,16 +6,12 @@ Robots are substituted by the <<Robot Handler, robot handler>> of the respective
 
 . Robots can always be substituted during game play if the following specifications are respected:
 
-.. Is at least partially inside the <<Field Surface, field margin>>
-.. At a distance from the halfway line that must not exceed 30 centimeters
+.. The robot is at least partially inside the <<Field Surface, field margin>>
+.. The robot is at a distance from the halfway line that must not exceed 1 meter
 .. The ball must be at least 2 meters away from the halfway line
 
-. If the previous specifications are respected, the <<Robot Handler, robot handler>> is allowed to perform the following operations.
-... Put robots in, without notifying the <<Referee, referee>>.
-... Take robots out, without notifying the <<Referee, referee>>.
-
-. Given that robots can be put in at any time, while respecting the previous specifications, on a game stoppage robots can only be removed.
-.. A <<Robot Handler, robot handler>> who's team is marked for robot substitution performs the following operation in the given order.
+. If the previous specifications are respected, the <<Robot Handler, robot handler>> is allowed to put robots in and take robots out, without notifying the <<Referee, referee>>.
+.. Additionally, robots can be taken out from any position during game stoppage by the <<Robot Handler, robot handler>> using the procedure below:
 ... Take robots out.
 ... The <<Robot Handler, robot handler>> informs the <<Referee, referee>> when done.
 ... When both teams finished the robot substitution, the <<Referee, referee>> informs the <<Game Controller Operator, game controller operator>>.
@@ -23,7 +19,7 @@ Robots are substituted by the <<Robot Handler, robot handler>> of the respective
 
 . If one of the robots taken out is the keeper, the <<Robot Handler, robot handler>> tells the <<Game Controller Operator, game controller operator>> the id of the robot that takes over the keeper role.
 
-. The maximum allowed number of robots of the team on the field must not be exceeded.
+. The maximum allowed number of robots of the team on the field must not be exceeded at any time.
 
 
 .Usage
@@ -32,6 +28,7 @@ Robots can be substituted for any reason. There is no limit on the number of sub
 A robot substitution intent can be made by:
 
 . A <<Robot Handler, robot handler>> by informing the <<Game Controller Operator, game controller operator>> who in turn enters the intent into the <<Game Controller, game controller>>.
+. A team software by sending a request to the <<Game Controller, game controller>>.
 . The <<Game Controller, game controller>> itself if a team exceeds the maximum number of robots (for example after a team receives a <<Yellow Card, yellow>> or <<Red Card, red card>>).
 
 If the game was halted due to a substitution intent by a team, at least one substitution (taking a robot out or putting one in) must be performed by this team. A substitution intent can be revoked unless the game was not already halted for substitution.

--- a/chapters/substitution.adoc
+++ b/chapters/substitution.adoc
@@ -4,16 +4,15 @@ Robots are substituted by the <<Robot Handler, robot handler>> of the respective
 
 The <<Robot Handler, robot handler>> should prefer to use long sleeves and colors that won't interfere with the vision system.
 
-Robots can always be substituted during game play without notifying the <<Referee, referee>> if the following specifications are respected:
+Robots can always be substituted during game play without notifying the <<Referee, referee>> if all the following conditions are met:
 
 . The robot is at least partially inside the <<Field Surface, field margin>>.
 . The robot is at a distance from the halfway line that must not exceed 1 meter.
 . The ball must be at least 2 meters away from the halfway line.
 
-
 Additionally, robots can be taken out from any position during <<Stopping The Game, game stoppage>> by the <<Robot Handler, robot handler>> using the procedure below:
 
-. Take robots out.
+. The <<Robot Handler, robot handler>> takes robots out.
 . The <<Robot Handler, robot handler>> informs the <<Referee, referee>> when done.
 . When both teams finished the robot substitution, the <<Referee, referee>> informs the <<Game Controller Operator, game controller operator>>.
 . The <<Game Controller Operator, game controller operator>> performs a <<Stop, stop>> followed by continuing the game.
@@ -21,7 +20,6 @@ Additionally, robots can be taken out from any position during <<Stopping The Ga
 If one of the robots taken out is the keeper, the <<Robot Handler, robot handler>> tells the <<Game Controller Operator, game controller operator>> the id of the robot that takes over the keeper role.
 
 The maximum allowed number of robots of the team on the field must not be exceeded at any time.
-
 
 .Usage
 Robots can be substituted for any reason. There is no limit on the number of substitutions.

--- a/chapters/substitution.adoc
+++ b/chapters/substitution.adoc
@@ -2,24 +2,28 @@
 .Definition
 Robots are substituted by the <<Robot Handler, robot handler>> of the respective team. No other team member is allowed to take robots out or put robots in.
 
-. Robot substitution during game play:
-.. The <<Robot Handler, robot handler>> should prefer to use long sleeves and colors that won't interfere with the vision system.
-.. A robot can only be substituted while obeying the following specifications:
-... Is at least on top of any touch line, if possible the robot can also be placed beyond the field boundaries
-... At a distance from the halfway line that must not exceed 30 centimeters
-.. A <<Robot Handler, robot handler>> who's team is marked for robot substitution performs the following operations.
-... Put robots in. If the ball is at least 2 meters away from the halfway line, the robot can be substituted without notifying the <<Referee, referee>>.
-... Take robots out. If the robot is placed at the previous specified position and the ball is at least 2 meters away from the halfway line, the robot can be removed without notifying the <<Referee, referee>>.
+. The <<Robot Handler, robot handler>> should prefer to use long sleeves and colors that won't interfere with the vision system.
 
-. Robot substitution on next stoppage:
-.. A <<Robot Handler, robot handler>> who's team is marked for robot substitution performs the following operations.
-... Put robots in. The maximum allowed number of robots of the team on the field must not be exceeded.
-... Take robots out. If a robot that is taken out is closer than 1 meter to the intersection of the halfway line with one of the touch lines, another robot can be put in right away. Otherwise the robot handler has to wait until the next substitution opportunity.
+. Robots can always be substituted during game play if the following specifications are respected:
+
+.. Is at least partially inside the <<Field Surface, field margin>>
+.. At a distance from the halfway line that must not exceed 30 centimeters
+.. The ball must be at least 2 meters away from the halfway line
+
+. If the previous specifications are respected, the <<Robot Handler, robot handler>> is allowed to perform the following operations.
+... Put robots in, without notifying the <<Referee, referee>>.
+... Take robots out, without notifying the <<Referee, referee>>.
+
+. Given that robots can be put in at any time, while respecting the previous specifications, on a game stoppage robots can only be removed.
+.. A <<Robot Handler, robot handler>> who's team is marked for robot substitution performs the following operation in the given order.
+... Take robots out.
 ... The <<Robot Handler, robot handler>> informs the <<Referee, referee>> when done.
 ... When both teams finished the robot substitution, the <<Referee, referee>> informs the <<Game Controller Operator, game controller operator>>.
 ... The <<Game Controller Operator, game controller operator>> performs a <<Stop, stop>> followed by continuing the game.
 
 . If one of the robots taken out is the keeper, the <<Robot Handler, robot handler>> tells the <<Game Controller Operator, game controller operator>> the id of the robot that takes over the keeper role.
+
+. The maximum allowed number of robots of the team on the field must not be exceeded.
 
 
 .Usage
@@ -28,9 +32,7 @@ Robots can be substituted for any reason. There is no limit on the number of sub
 A robot substitution intent can be made by:
 
 . A <<Robot Handler, robot handler>> by informing the <<Game Controller Operator, game controller operator>> who in turn enters the intent into the <<Game Controller, game controller>>.
-. A team software by sending a request to the <<Game Controller, game controller>>.
 . The <<Game Controller, game controller>> itself if a team exceeds the maximum number of robots (for example after a team receives a <<Yellow Card, yellow>> or <<Red Card, red card>>).
-. *(Division A only)* If a robot needs to be taken out and it is not in the mid line, a timeout needs to be taken in order for the team to remove the robot from the field. If a team is out of timeouts, it will still be able to take the robot out, however, it will not be able to use any remaining timeout time, the robot must be removed from the field as fast as possible.
 
 If the game was halted due to a substitution intent by a team, at least one substitution (taking a robot out or putting one in) must be performed by this team. A substitution intent can be revoked unless the game was not already halted for substitution.
 

--- a/chapters/substitution.adoc
+++ b/chapters/substitution.adoc
@@ -17,8 +17,6 @@ Additionally, robots can be taken out from any position during <<Stopping The Ga
 . When both teams finished the robot substitution, the <<Referee, referee>> informs the <<Game Controller Operator, game controller operator>>.
 . The <<Game Controller Operator, game controller operator>> performs a <<Stop, stop>> followed by continuing the game.
 
-If one of the robots taken out is the keeper, the <<Robot Handler, robot handler>> tells the <<Game Controller Operator, game controller operator>> the id of the robot that takes over the keeper role.
-
 The maximum allowed number of robots of the team on the field must not be exceeded at any time.
 
 .Usage

--- a/chapters/substitution.adoc
+++ b/chapters/substitution.adoc
@@ -2,13 +2,13 @@
 .Definition
 Robots are substituted by the <<Robot Handler, robot handler>> of the respective team. No other team member is allowed to take robots out or put robots in.
 
-. Robot substitution during game play - Division A only:
+. Robot substitution during game play:
 .. The <<Robot Handler, robot handler>> should prefer to use long sleeves and colors that won't interfere with the vision system.
 .. A <<Robot Handler, robot handler>> who's team is marked for robot substitution performs at least one of the following operations in the given order.
 ... Put robots in. If the ball is at least 2 meters away from the halfway line, the robot can be placed on the intersection of the halfway line with any touch line without notifying the <<Referee, referee>>.
 ... Take robots out. If a robot is at the intersection of the halfway line with any touch line and the ball is at least 2 meters away from the halfway line, the robot can be removed without notifying the <<Referee, referee>>.
 
-. Robot substitution on next stoppage - Both Divisions:
+. Robot substitution on next stoppage:
 .. A <<Robot Handler, robot handler>> who's team is marked for robot substitution performs at least one of the following operations in the given order.
 ... Put robots in. The maximum allowed number of robots of the team on the field must not be exceeded.
 ... Take robots out. If a robot that is taken out is closer than 1 meter to the intersection of the halfway line with one of the touch lines, another robot can be put in right away. Otherwise the robot handler has to wait until the next substitution opportunity.

--- a/chapters/substitution.adoc
+++ b/chapters/substitution.adoc
@@ -5,8 +5,8 @@ Robots are substituted by the <<Robot Handler, robot handler>> of the respective
 . Robot substitution during game play - Division A only:
 .. The <<Robot Handler, robot handler>> should prefer to use long sleeves and colors that won't interfere with the vision system.
 .. A <<Robot Handler, robot handler>> who's team is marked for robot substitution performs at least one of the following operations in the given order.
-... Put robots in during game play. If the ball is at least 2 meters away from the mid line, the robot can be placed in it without notifying the <<Referee, referee>>.
-... Take robots out during game play (Division A only). If a robot is at the mid line and the ball is at least 2 meters away from the mid line, the robot can be removed without notifying the <<Referee, referee>>.
+... Put robots in. If the ball is at least 2 meters away from the halfway line, the robot can be placed on the intersection of the halfway line with any touch line without notifying the <<Referee, referee>>.
+... Take robots out. If a robot is at the intersection of the halfway line with any touch line and the ball is at least 2 meters away from the halfway line, the robot can be removed without notifying the <<Referee, referee>>.
 
 . Robot substitution on next stoppage - Both Divisions:
 .. A <<Robot Handler, robot handler>> who's team is marked for robot substitution performs at least one of the following operations in the given order.

--- a/chapters/substitution.adoc
+++ b/chapters/substitution.adoc
@@ -2,9 +2,14 @@
 .Definition
 Robots are substituted by the <<Robot Handler, robot handler>> of the respective team. No other team member is allowed to take robots out or put robots in.
 
+. The <<Robot Handler, robot handler>> must preferably not wear colors that may interfere with the vision system.
+.. If non-stop robot interchange is allowed (Division A), the <<Robot Handler, robot handler>> should preffer using long sleeves.
+
 . A <<Robot Handler, robot handler>> who's team is marked for robot substitution performs at least one of the following operations in the given order.
 .. Put robots in. The maximum allowed number of robots of the team on the field must not be exceeded.
+.. Put robots in during game play (Division A only). If the ball is at least 2 meters away from the midline, the robot can be placed in it without notifying the <<Referee, referee>>.
 .. Take robots out. If a robot that is taken out is closer than 1 meter to the intersection of the halfway line with one of the touch lines, another robot can be put in right away. Otherwise the robot handler has to wait until the next substitution opportunity.
+.. Take robots out during game play (Division A only). If a robot is at the midline and the ball is at least 2 meters away from the midline, the robot can be removed without notifying the <<Referee, referee>>.
 . If one of the robots taken out is the keeper, the <<Robot Handler, robot handler>> tells the <<Game Controller Operator, game controller operator>> the id of the robot that takes over the keeper role.
 . The <<Robot Handler, robot handler>> informs the <<Referee, referee>> when done.
 . When both teams finished the robot substitution, the <<Referee, referee>> informs the <<Game Controller Operator, game controller operator>>.

--- a/chapters/substitution.adoc
+++ b/chapters/substitution.adoc
@@ -2,24 +2,25 @@
 .Definition
 Robots are substituted by the <<Robot Handler, robot handler>> of the respective team. No other team member is allowed to take robots out or put robots in.
 
-. The <<Robot Handler, robot handler>> should prefer to use long sleeves and colors that won't interfere with the vision system.
+The <<Robot Handler, robot handler>> should prefer to use long sleeves and colors that won't interfere with the vision system.
 
-. Robots can always be substituted during game play if the following specifications are respected:
+Robots can always be substituted during game play without notifying the <<Referee, referee>> if the following specifications are respected:
 
-.. The robot is at least partially inside the <<Field Surface, field margin>>
-.. The robot is at a distance from the halfway line that must not exceed 1 meter
-.. The ball must be at least 2 meters away from the halfway line
+. The robot is at least partially inside the <<Field Surface, field margin>>.
+. The robot is at a distance from the halfway line that must not exceed 1 meter.
+. The ball must be at least 2 meters away from the halfway line.
 
-. If the previous specifications are respected, the <<Robot Handler, robot handler>> is allowed to put robots in and take robots out, without notifying the <<Referee, referee>>.
-.. Additionally, robots can be taken out from any position during game stoppage by the <<Robot Handler, robot handler>> using the procedure below:
-... Take robots out.
-... The <<Robot Handler, robot handler>> informs the <<Referee, referee>> when done.
-... When both teams finished the robot substitution, the <<Referee, referee>> informs the <<Game Controller Operator, game controller operator>>.
-... The <<Game Controller Operator, game controller operator>> performs a <<Stop, stop>> followed by continuing the game.
 
-. If one of the robots taken out is the keeper, the <<Robot Handler, robot handler>> tells the <<Game Controller Operator, game controller operator>> the id of the robot that takes over the keeper role.
+Additionally, robots can be taken out from any position during <<Stopping The Game, game stoppage>> by the <<Robot Handler, robot handler>> using the procedure below:
 
-. The maximum allowed number of robots of the team on the field must not be exceeded at any time.
+. Take robots out.
+. The <<Robot Handler, robot handler>> informs the <<Referee, referee>> when done.
+. When both teams finished the robot substitution, the <<Referee, referee>> informs the <<Game Controller Operator, game controller operator>>.
+. The <<Game Controller Operator, game controller operator>> performs a <<Stop, stop>> followed by continuing the game.
+
+If one of the robots taken out is the keeper, the <<Robot Handler, robot handler>> tells the <<Game Controller Operator, game controller operator>> the id of the robot that takes over the keeper role.
+
+The maximum allowed number of robots of the team on the field must not be exceeded at any time.
 
 
 .Usage


### PR DESCRIPTION
From the Rule proposal:

> We aim for less stoppages and especially with walls, there will probably be much less chances to interchange robots. We already encourage teams to automatically interchange robots by replacing them at the midline, but the game still had to be stopped and even halted in 2019. This wasted overall game time.
> 
> We propose that robots can always be taken in and out from the midline. No need to stop the game. There should not be any action at the midline during the replacement. That could be enforced by requiring that the ball is not near the interchange position.


> In 2019, a lot of time was lost in HALT, while teams interchanged their robots.
> We want to encourage teams to reduce the number of manual interchanges to a minimum and make use of the automatic interchange to save overall game time.
> 
> We propose that manual robot interchange (if the robot is not taken in/out from the midline) always requires a timeout to be taken.
> If a team is out of timeouts and still needs to take one robot out, the team is allowed to take the robot out without a timeout, but can not use any remaining timeout time. It can only remove the robot from the field as fast as possible.
> 