### PR TITLE
Emergency stop (Div A)

### DIFF
--- a/chapters/emergencystop.adoc
+++ b/chapters/emergencystop.adoc
@@ -3,29 +3,24 @@
 This rule only applies to Division A.
 
 .Definition
+A team can ask to stop the game immediately after a grace period of 10 seconds or at the next stoppage, whichever happens first regardless of the current situation.
+It will receive a yellow card for this and must take a timeout immediately.
+If the team is out of timeouts, it is still allowed to remove robots from the field, but can not use any remaining timeout time.
 
-A team can ask to stop the game immediately after a grace period of 10 seconds or at the next stoppage, whichever happens first regardless of the current situation. It will receive a yellow card for this and must take a timeout immediately. If the team is out of timeouts, it is still allowed to remove robots from the field, but can not use any remaining timeout time.
-
-NOTE: This rule is supposed to only be used in extreme situations, e.g. a software crash or the robots starts damaging themselves.
+NOTE: This rule is supposed to be used in extreme situations only, e.g. a software crash or when robots are damaging themselves significantly.
 
 When the game is stopped due to this rule, there are three possibilities that may have happened:
 
-. 10 seconds have passed and the game is stopped.
-. The game is stopped earlier than 10 seconds due to the ball leaving the field or a foul occurred.
-. The human referee stopped the game manually earlier than 10 seconds.
+. The grace period has passed and the game is stopped.
+. The human referee stopped the game earlier.
+. The game is stopped earlier due to the ball leaving the field or because of a foul.
 
 For these possibilities there are two methods to proceed the game:
 
-. For *1* and *3*, the game is continued with a free kick for the opposing team.
-. For *2*, the game is continued like after a regular timeout.
+. For *1* and *2*, the game is continued with a <<Free Kick, free kick>> for the opposing team.
+. For *3*, the game is continued like after a regular timeout.
 
 .Usage
+An emergency stop intent can be made using <<Communication Flags, communication flags>>.
 
-An emergency stop intent can be made by:
-
-// To inform the referee a communication flag shall be used
-// TODO: link "informing" with the communication flag section
-
-. A <<Robot Handler, robot handler>> by informing the <<Referee, referee>> who shall stop the game within 10 seconds.
-
-NOTE: The Official Team Remote Control is just an option, if it is not available, the referee is allowed to stop the game earlier than 10 seconds, if there isn't an important play in action, e.g. no team is at the risk of scoring a goal or the ball is close to the halfway line.
+NOTE: The referee may to stop the game earlier if there is no promising play in action.

--- a/chapters/emergencystop.adoc
+++ b/chapters/emergencystop.adoc
@@ -1,0 +1,13 @@
+== Emergency stop
+
+This rule only applies to Division A.
+
+.Definition
+
+A team can ask to stop the game immediately after a grace period of 10 seconds or at the next stoppage, whichever happens first regardless of the current situation. It will receive a yellow card for this and must take a timeout immediately. If the team is out of timeouts, it is still allowed to remove robots from the field, but can not use any remaining timeout time.
+
+.Usage
+
+A emergency stop intent can be made by:
+
+. A <<Robot Handler, robot handler>> by informing the <<Game Controller Operator, game controller operator>> who in turn enters the intent into the <<Game Controller, game controller>>.

--- a/chapters/emergencystop.adoc
+++ b/chapters/emergencystop.adoc
@@ -6,6 +6,17 @@ This rule only applies to Division A.
 
 A team can ask to stop the game immediately after a grace period of 10 seconds or at the next stoppage, whichever happens first regardless of the current situation. It will receive a yellow card for this and must take a timeout immediately. If the team is out of timeouts, it is still allowed to remove robots from the field, but can not use any remaining timeout time.
 
+There are three possible situations when this rule is used:
+
+. 10 seconds have passed and the game is stopped;
+. The game is stopped earlier than 10 seconds due to the ball leaving the field or a foul occurred;
+. The human referee stopped the game manually earlier than 10 seconds.
+
+And there are two methods of restarting the game:
+
+. For situation 1 and 3, the game is continued with a free kick for the opposing team;
+. For situation 2, the game is continued like a regular timeout.
+
 .Usage
 
 An emergency stop intent can be made by:

--- a/chapters/emergencystop.adoc
+++ b/chapters/emergencystop.adoc
@@ -8,11 +8,11 @@ A team can ask to stop the game immediately after a grace period of 10 seconds o
 
 .Usage
 
-A emergency stop intent can be made by:
+An emergency stop intent can be made by:
 
 // To inform the referee a communication flag shall be used
 // TODO: link "informing" with the communication flag section
 
 . A <<Robot Handler, robot handler>> by informing the <<Referee, referee>> who shall stop the game within 10 seconds or at the next stoppage.
 
-NOTE: Until we implement an automatic procedure, e.g. Raspberry PI, the referee is allowed to stop the game earlier than 10 seconds, if there isn't a important play in action, e.g. no team is at the risk of scoring a goal or the ball is close to the halfway line.
+NOTE: Until we implement an automatic procedure, e.g. Raspberry PI, the referee is allowed to stop the game earlier than 10 seconds, if there isn't an important play in action, e.g. no team is at the risk of scoring a goal or the ball is close to the halfway line.

--- a/chapters/emergencystop.adoc
+++ b/chapters/emergencystop.adoc
@@ -10,4 +10,9 @@ A team can ask to stop the game immediately after a grace period of 10 seconds o
 
 A emergency stop intent can be made by:
 
-. A <<Robot Handler, robot handler>> by informing the <<Game Controller Operator, game controller operator>> who in turn enters the intent into the <<Game Controller, game controller>>.
+// To inform the referee a communication flag shall be used
+// TODO: link "informing" with the communication flag section
+
+. A <<Robot Handler, robot handler>> by informing the <<Referee, referee>> who shall stop the game within 10 seconds or at the next stoppage.
+
+NOTE: Until we implement an automatic procedure, e.g. Raspberry PI, the referee is allowed to stop the game earlier than 10 seconds, if there isn't a important play in action, e.g. no team is at the risk of scoring a goal or the ball is close to the halfway line.

--- a/chapters/emergencystop.adoc
+++ b/chapters/emergencystop.adoc
@@ -6,16 +6,18 @@ This rule only applies to Division A.
 
 A team can ask to stop the game immediately after a grace period of 10 seconds or at the next stoppage, whichever happens first regardless of the current situation. It will receive a yellow card for this and must take a timeout immediately. If the team is out of timeouts, it is still allowed to remove robots from the field, but can not use any remaining timeout time.
 
+NOTE: This rule is supposed to only be used in extreme situations, e.g. a software crash or the robots starts damaging themselves.
+
 When the game is stopped due to this rule, there are three possibilities that may have happened:
 
-. 10 seconds have passed and the game is stopped;
-. The game is stopped earlier than 10 seconds due to the ball leaving the field or a foul occurred;
+. 10 seconds have passed and the game is stopped.
+. The game is stopped earlier than 10 seconds due to the ball leaving the field or a foul occurred.
 . The human referee stopped the game manually earlier than 10 seconds.
 
 For these possibilities there are two methods to proceed the game:
 
-. For *1* and *3*, the game is continued with a free kick for the opposing team;
-. For *2*, the game is continued like a regular timeout.
+. For *1* and *3*, the game is continued with a free kick for the opposing team.
+. For *2*, the game is continued like after a regular timeout.
 
 .Usage
 
@@ -24,6 +26,6 @@ An emergency stop intent can be made by:
 // To inform the referee a communication flag shall be used
 // TODO: link "informing" with the communication flag section
 
-. A <<Robot Handler, robot handler>> by informing the <<Referee, referee>> who shall stop the game within 10 seconds or at the next stoppage.
+. A <<Robot Handler, robot handler>> by informing the <<Referee, referee>> who shall stop the game within 10 seconds.
 
-NOTE: Until we implement an automatic procedure, e.g. Raspberry PI, the referee is allowed to stop the game earlier than 10 seconds, if there isn't an important play in action, e.g. no team is at the risk of scoring a goal or the ball is close to the halfway line.
+NOTE: The Official Team Remote Control is just an option, if it is not available, the referee is allowed to stop the game earlier than 10 seconds, if there isn't an important play in action, e.g. no team is at the risk of scoring a goal or the ball is close to the halfway line.

--- a/chapters/emergencystop.adoc
+++ b/chapters/emergencystop.adoc
@@ -6,16 +6,16 @@ This rule only applies to Division A.
 
 A team can ask to stop the game immediately after a grace period of 10 seconds or at the next stoppage, whichever happens first regardless of the current situation. It will receive a yellow card for this and must take a timeout immediately. If the team is out of timeouts, it is still allowed to remove robots from the field, but can not use any remaining timeout time.
 
-There are three possible situations when this rule is used:
+When the game is stopped due to this rule, there are three possibilities that may have happened:
 
 . 10 seconds have passed and the game is stopped;
 . The game is stopped earlier than 10 seconds due to the ball leaving the field or a foul occurred;
 . The human referee stopped the game manually earlier than 10 seconds.
 
-And there are two methods of restarting the game:
+For these possibilities there are two methods to proceed the game:
 
-. For situation 1 and 3, the game is continued with a free kick for the opposing team;
-. For situation 2, the game is continued like a regular timeout.
+. For *1* and *3*, the game is continued with a free kick for the opposing team;
+. For *2*, the game is continued like a regular timeout.
 
 .Usage
 

--- a/chapters/emergencystop.adoc
+++ b/chapters/emergencystop.adoc
@@ -23,4 +23,4 @@ For these possibilities there are two methods to proceed the game:
 .Usage
 An emergency stop intent can be made using <<Communication Flags, communication flags>>.
 
-NOTE: The referee may to stop the game earlier if there is no promising play in action.
+NOTE: The referee may stop the game earlier if there is no promising play in action.

--- a/sslrules.adoc
+++ b/sslrules.adoc
@@ -36,4 +36,6 @@ include::chapters/substitution.adoc[]
 
 include::chapters/shootout.adoc[]
 
+include::chapters/emergencystop.adoc[]
+
 include::chapters/appendix.adoc[]


### PR DESCRIPTION
From the rule change proposal:

> With less stoppages, there are fewer chances to get a robot from the field manually. Even with a timeout, the team would need to wait until the next stoppage.
> If something goes really wrong with a teams robot (like damaging itself more and more), the team might want to stop the game to reduce the damage (and any cost due to destroyed parts).
> 
> Proposal: A team can ask to stop the game immediately after a grace period of 10s, regardless of the current situation. It will receive a yellow card for this and must take a timeout immediately. If the team is out of timeouts, it is still allowed to remove robots from the field as fast as possible, but can not use any remaining timeout time
