### PR TITLE
Add rule for rule changes during competition

### DIFF
--- a/chapters/rulechanges.adoc
+++ b/chapters/rulechanges.adoc
@@ -1,0 +1,8 @@
+== Rule Changes During Competition
+
+Rule changes between years can have unforeseen consequences.
+If a rule is found to cause significant negative impact to the competition, the rules may be adapted under the following conditions:
+
+* Only between phases of the competition, like round-robin and knockout
+* Only for major problems, as a last resort
+* The change must be approved by all team leaders (by an unanimity vote)

--- a/sslrules.adoc
+++ b/sslrules.adoc
@@ -38,4 +38,6 @@ include::chapters/shootout.adoc[]
 
 include::chapters/emergencystop.adoc[]
 
+include::chapters/rulechanges.adoc[]
+
 include::chapters/appendix.adoc[]


### PR DESCRIPTION
From the rules proposal:

> We as TC/OC/EC try our best to come up with adequate rule changes that will improve the league. But there will always be an uncertainty that can only be clarified by actually running a competition. If we notice, during the competition, that some rule is not working out as expected, we’ll open up the possibilities to adapt the rules:
> * Between phases of the competition: Round-Robin / knockout / tournament
> * Only invoked if we find major problems, as a last resort
> * This is not an “out” for the rules making, to iron out details through regionals, testing, other avenues
> * We will involve all team leaders into the decision