### PR TITLE
Add a cost to manual robot interchange (Div A)

### DIFF
--- a/chapters/substitution.adoc
+++ b/chapters/substitution.adoc
@@ -18,7 +18,7 @@ A robot substitution intent can be made by:
 . A <<Robot Handler, robot handler>> by informing the <<Game Controller Operator, game controller operator>> who in turn enters the intent into the <<Game Controller, game controller>>.
 . A team software by sending a request to the <<Game Controller, game controller>>.
 . The <<Game Controller, game controller>> itself if a team exceeds the maximum number of robots (for example after a team receives a <<Yellow Card, yellow>> or <<Red Card, red card>>).
-. *(Division A only)* If a robot needs to be taken out and it is not in the mid line, a timeout needs to be taken in order for the team to remove the robot from the field. If a team is out of timeouts, it will still be able to take the robot out, however, it will not be able to use any remaining timeout time, the robot must be removed from the field as fast as possible.
+. *(Division A only)* If a robot can not be taken out in the substitution area, a timeout needs to be taken in order for the team to remove the robot from the field. If a team is out of timeouts, it will still be able to take the robot out, however, it will not be able to use any remaining timeout time, the robot must be removed from the field as fast as possible.
 
 If the game was halted due to a substitution intent by a team, at least one substitution (taking a robot out or putting one in) must be performed by this team. A substitution intent can be revoked unless the game was not already halted for substitution.
 

--- a/chapters/substitution.adoc
+++ b/chapters/substitution.adoc
@@ -18,6 +18,7 @@ A robot substitution intent can be made by:
 . A <<Robot Handler, robot handler>> by informing the <<Game Controller Operator, game controller operator>> who in turn enters the intent into the <<Game Controller, game controller>>.
 . A team software by sending a request to the <<Game Controller, game controller>>.
 . The <<Game Controller, game controller>> itself if a team exceeds the maximum number of robots (for example after a team receives a <<Yellow Card, yellow>> or <<Red Card, red card>>).
+. *(Division A only)* If a robot needs to be taken out and it is not in the mid line, a timeout needs to be taken in order for the team to remove the robot from the field. If a team is out of timeouts, it will still be able to take the robot out, however, it will not be able to use any remaining timeout time, the robot must be removed from the field as fast as possible.
 
 If the game was halted due to a substitution intent by a team, at least one substitution (taking a robot out or putting one in) must be performed by this team. A substitution intent can be revoked unless the game was not already halted for substitution.
 


### PR DESCRIPTION
From the rule changes proposal:

> In 2019, a lot of time was lost in HALT, while teams interchanged their robots.
> We want to encourage teams to reduce the number of manual interchanges to a minimum and make use of the automatic interchange to save overall game time.
> 
> We propose that manual robot interchange (if the robot is not taken in/out from the midline) always requires a timeout to be taken.
> If a team is out of timeouts and still needs to take one robot out, the team is allowed to take the robot out without a timeout, but can not use any remaining timeout time. It can only remove the robot from the field as fast as possible.
