### PR TITLE
Change lack of progress timeout and behavior

### DIFF
--- a/chapters/appendix.adoc
+++ b/chapters/appendix.adoc
@@ -60,8 +60,9 @@ Chapter <<Offenses>>, section <<Minor Offenses>>:
 | Event | Applicability | Command | AutoRef
 
 | <<Aimless Kick [small]#(_division B only_)#, Aimless Kick>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Indirect Free Kick>> | icon:check[role="green"]
-| <<Lack Of Progress>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Force Start>> | icon:check[role="green"]
+| <<Lack Of Progress>> during <<Kick-Off>>, <<Direct Free Kick>>, <<Indirect Free Kick>> | <<Ball In And Out Of Play, ball in play>> | Ball is considered in-play and manipulatable by both teams | icon:check[role="green"]
 | <<Lack Of Progress>> ball in <<Defense Area, defense area>> | <<Ball In And Out Of Play, ball in play>> | <<Indirect Free Kick, indirect free kick>> | icon:check[role="green"]
+| <<Lack Of Progress>>, otherwise | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Force Start>> | icon:check[role="green"]
 | <<Double Touch>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Indirect Free Kick>> | icon:check[role="green"]
 | <<Attacker In Defense Area>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Indirect Free Kick>> | icon:check[role="green"]
 | <<Attacker Touches Robot In Opponent Defense Area>> skipped | <<Ball In And Out Of Play, ball in play>> | no command | icon:check[role="green"] (<<Advantage Rule>>)

--- a/chapters/appendix.adoc
+++ b/chapters/appendix.adoc
@@ -60,7 +60,8 @@ Chapter <<Offenses>>, section <<Minor Offenses>>:
 | Event | Applicability | Command | AutoRef
 
 | <<Aimless Kick [small]#(_division B only_)#, Aimless Kick>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Indirect Free Kick>> | icon:check[role="green"]
-| <<Lack Of Progress>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Indirect Free Kick>> | icon:check[role="green"]
+| <<Lack Of Progress>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Force Start>> | icon:check[role="green"]
+| <<Lack Of Progress>> ball in <<Defense Area, defense area>> | <<Ball In And Out Of Play, ball in play>> | <<Indirect Free Kick, indirect free kick>> | icon:check[role="green"]
 | <<Double Touch>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Indirect Free Kick>> | icon:check[role="green"]
 | <<Attacker In Defense Area>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Indirect Free Kick>> | icon:check[role="green"]
 | <<Attacker Touches Robot In Opponent Defense Area>> skipped | <<Ball In And Out Of Play, ball in play>> | no command | icon:check[role="green"] (<<Advantage Rule>>)
@@ -113,4 +114,4 @@ This is a complete list of differences between <<Divisions, division>> A and <<D
 * Division A plays with <<Number Of Robots, more robots>> than division B.
 * The automatic <<Ball Placement, ball placement>> procedure is mandatory for division A and optional for division B.
 * The <<Aimless Kick [small]#(_division B only_)#, aimless kick>> rule only applies to division B.
-* There is a smaller time window in division A for taking a free kick before <<Lack Of Progress, lack of progress>> is called.
+* There is a smaller time window in division A before <<Lack Of Progress, lack of progress>> is called.

--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -44,7 +44,7 @@ kick>>, <<Indirect Free Kick, indirect free kick>>, after the time
 expires the ball is considered <<Ball In And Out Of Play, in play>>
 and both teams may manipulate the ball.
 
-In all other cases a <<Stop>> is issued followed by a <<Force Start>>
+In all other cases a <<Stop, stop>> is issued followed by a <<Force Start, forced start>>.
 This includes situations where both teams can manipulate the ball, but
 the referee determines that no progress is being made.
 

--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -12,13 +12,34 @@ All minor offenses are listed below.
 A kick is aimless when after the ball touched a robot, it subsequently crossed the midline and then its opponent's goal line outside the goal without touching another robot. A kick-off kick cannot be aimless, as the ball is located at the midline and does therefore not cross it.
 
 ==== Lack Of Progress
-There is a lack of progress if only one team is allowed to <<Ball Manipulation, manipulate the ball>> (<<Kick-Off, kick-off>>, <<Direct Free Kick, direct free kick>>, <<Indirect Free Kick, indirect free kick>>, <<Penalty Kick, penalty kick>>) and does not bring the ball <<Ball In And Out Of Play, into play>> in time. The time limit is 5 seconds for <<Indirect Free Kick, indirect free kicks>> and <<Direct Free Kick, direct free kicks>> in division A and 10 seconds in all other cases.
 
-There is also a lack of progress if the ball is inside a team's <<Defense Area, defense area>> for 10 seconds, since the keeper is the only robot that is allowed to <<Ball Manipulation, manipulate the ball>>.
+There is a lack of progress if only one team is allowed to <<Ball
+Manipulation, manipulate the ball>> (<<Kick-Off, kick-off>>, <<Direct
+Free Kick, direct free kick>>, <<Indirect Free Kick, indirect free
+kick>>, <<Penalty Kick, penalty kick>>) and does not bring the ball
+<<Ball In And Out Of Play, into play>> in time. The time before lack
+of progress is called is described in the table: <<lack-of-progress-timings>>.
 
-NOTE: If both teams are allowed to manipulate the ball, and thus no team is at fault, the referee may stop the game and issue a <<Force Start, force start>> command.
+[frame="topbot",options="header"]
+.Lack Of Progress Timings
+[[lack-of-progress-timings]]
+|=============================================================================
+| Situation                                                                   | Div A Time | Div B Time
+| <<Kick-Of, kick-off>>                                                     | 10 s       | 10 s
+| <<Penalty Kick, penalty kick>>                                          | 10 s       | 10 s               
+| <<Direct Free Kick, direct free kick>>                                 | 5 s        | 10 s        
+| <<Indirect Free Kick, indirect free kick>>                            | 5 s        | 10 s                  
+| Ball inside <<Defense Area, defense area>>                              | 5 s        | 10 s                  
+| Both teams can manipulate, no progress                                      | 5 s        | 10 s                  
+| Neither team can bring ball <<Ball In And Out Of Play, into play>>  | 5 s        | 10 s                  
+|=============================================================================
 
-NOTE: If both teams are clearly unable to bring the ball <<Ball In And Out Of Play, into play>> without violating the rules, the referee may issue a <<Force Start, force start>> command instead of an <<Indirect Free Kick, indirect free kick>> for the other team.
+
+If there is a lack of progress due to the ball being inside a team's
+<<Defense Area, defense area>> past the timeout, then a <<Indirect Free
+Kick, indirect free kick>> is issued for the attacking team.
+
+In all other cases, a <<Stop>> then a <<Force Start>> command is issued.
 
 ==== Double Touch
 When the ball is brought <<Ball In And Out Of Play, into play>> following a <<Kick-Off, kick-off>>, <<Direct Free Kick, direct free kick>>, <<Indirect Free Kick, indirect free kick>> or <<Penalty Kick, penalty kick>>, the kicker is not allowed to touch the ball until it has been touched by another robot or the game has been stopped.

--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -25,7 +25,7 @@ of progress is called is described in the table: <<lack-of-progress-timings>>.
 [[lack-of-progress-timings]]
 |=============================================================================
 | Situation                                                                   | Div A Time | Div B Time
-| <<Kick-Of, kick-off>>                                                     | 10 s       | 10 s
+| <<Kick-Off, kick-off>>                                                     | 10 s       | 10 s
 | <<Penalty Kick, penalty kick>>                                          | 10 s       | 10 s               
 | <<Direct Free Kick, direct free kick>>                                 | 5 s        | 10 s        
 | <<Indirect Free Kick, indirect free kick>>                            | 5 s        | 10 s                  
@@ -39,7 +39,14 @@ If there is a lack of progress due to the ball being inside a team's
 <<Defense Area, defense area>> past the timeout, then a <<Indirect Free
 Kick, indirect free kick>> is issued for the attacking team.
 
-In all other cases, a <<Stop>> then a <<Force Start>> command is issued.
+In the case of <<Kick-Off, kick-off>>, <<Direct Free Kick, direct free
+kick>>, <<Indirect Free Kick, indirect free kick>>, after the time
+expires the ball is considered <<Ball In And Out Of Play, in play>>
+and both teams may manipulate the ball.
+
+In all other cases a <<Stop>> is issued followed by a <<Force Start>>
+This includes situations where both teams can manipulate the ball, but
+the referee determines that no progress is being made.
 
 ==== Double Touch
 When the ball is brought <<Ball In And Out Of Play, into play>> following a <<Kick-Off, kick-off>>, <<Direct Free Kick, direct free kick>>, <<Indirect Free Kick, indirect free kick>> or <<Penalty Kick, penalty kick>>, the kicker is not allowed to touch the ball until it has been touched by another robot or the game has been stopped.

--- a/chapters/refereecommands.adoc
+++ b/chapters/refereecommands.adoc
@@ -122,7 +122,8 @@ Indirect free kicks are used to restart the game after a <<Minor Offenses, minor
 When the force start command is issued, the game is immediately resumed and both teams are allowed to approach and <<Ball Manipulation, manipulate the ball>> again.
 
 .Usage
-The referee can issue a stop command followed by force start if there is a clear lack of progress for at least 10 seconds while both teams are allowed to approach and <<Ball Manipulation, manipulate the ball>>.
+The referee can issue a <<Stop, stop>> command followed by <<Force Start, forced start>> if there
+is a clear <<Lack Of Progress, lack of progress>>.
 
 It can also be used to resume the game when the game had to be stopped and no team or both teams are at fault.
 


### PR DESCRIPTION
Play now continues with a Force Start instead of an Indirect Free Kick.

Division A timeout changed to 5 seconds. Division B timeout remains at 10 seconds.

See proposed rule change spreadsheet: https://docs.google.com/spreadsheets/d/1LfNNrE4ld0IkRGXSkKSKOnPDipdKbuH-InZJY2kATs4/edit?usp=sharing