### PR TITLE
Change Attacker touches robot in defense penalties

### DIFF
--- a/chapters/appendix.adoc
+++ b/chapters/appendix.adoc
@@ -74,7 +74,7 @@ Chapter <<Offenses>>, section <<Fouls>>:
 | Event | Applicability | Command | AutoRef
 
 | Multiple <<Fouls>> | <<Ball In And Out Of Play, ball out of play>> | <<Yellow Card>> | icon:times[role="red"] (handled by the game controller)
-| <<Attacker Touches Robot In Opponent Defense Area>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Indirect Free Kick>> | icon:check[role="green"]
+| <<Attacker Touches Robot In Opponent Defense Area>> | <<Ball In And Out Of Play, ball in play>> | Goals within 2 seconds do not count, Increase <<Fouls, foul counter>> | icon:check[role="green"]
 | <<Robot Too Close To Opponent Defense Area>> | <<Ball In And Out Of Play, ball out of play>> | <<Stop>>, then <<Direct Free Kick>> | icon:check[role="green"]
 | <<Ball Placement Interference>> | during <<Ball Placement>> | <<Stop>>, then <<Direct Free Kick>> | icon:check[role="green"]
 | <<Crashing>> | always | <<Stop>>, then <<Direct Free Kick>> | icon:check[role="green"]

--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -70,6 +70,8 @@ All fouls are listed below.
 ==== Attacker Touches Robot In Opponent Defense Area
 When the ball <<Ball In And Out Of Play, in play>>, a robot must not touch any opponent robot inside the opponent <<Defense Area, defense area>>.
 
+Game continues but goals within 2 seconds of the end of the offense are not counted. Foul counter is increased.
+
 NOTE: When the ball is <<Ball In And Out Of Play, out of play>>, the rule <<Robot Too Close To Opponent Defense Area>> applies instead.
 
 ==== Robot Too Close To Opponent Defense Area

--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -41,11 +41,29 @@ NOTE: Dribblers can still be used to dribble large distances with the ball as lo
 A robot must not accelerate the ball faster than 6.5 meters per second in 3D space.
 
 === Fouls
-Fouls are violations of the rules that result in a <<Direct Free Kick, direct free kick>> for the opposing team. The free kick will be shot from the position where the offense began happening (see <<Direct Free Kick, the direct free kick rules>> for the exact ball position rules). If the foul happened while the ball is <<Ball In And Out Of Play, out of play>>, no free kick is given.
 
-Every third foul of the same team results in a <<Yellow Card, yellow card>>.
+Fouls are violations of the rules that result in a some combination of
+the following penalties:
 
-In case of severe fouls, the referee can also issue a <<Yellow Card, yellow card>> or a <<Red Card, red card>>.
+      - <<Direct Free Kick, direct free kick> for the opposing team
+      - An increase in the foul counter
+
+Some special case additional rules (such as goals not counting within
+some time-window of the offense) may apply based on the specific
+offense. See below for details on the specifics of the penalties for
+each offense type.
+
+Free kicks will be shot from the position where the offense began
+happening (see <<Direct Free Kick, the direct free kick rules>> for
+the exact ball position rules). If the foul happened while the ball is
+<<Ball In And Out Of Play, out of play>>, no free kick is given.
+
+Fouls are tracked via the game controller with a counter for each
+team. Every time the counter for a team reaches an increment of three
+a <<Yellow Card, yellow card>> is issued to the team.
+
+In case of severe fouls, the referee can also issue a <<Yellow Card,
+yellow card>> or a <<Red Card, red card>>.
 
 All fouls are listed below.
 


### PR DESCRIPTION
Remove stoppage and free kick.

Goals within 2 seconds of end of penalty do not count. Foul counter increases.

Rephrased Minor Offenses section as the old text is no longer accurate.

See https://docs.google.com/spreadsheets/d/1LfNNrE4ld0IkRGXSkKSKOnPDipdKbuH-InZJY2kATs4/edit?usp=sharing