### PR TITLE
Excessive dribbling penalties

### DIFF
--- a/chapters/appendix.adoc
+++ b/chapters/appendix.adoc
@@ -64,7 +64,7 @@ Chapter <<Offenses>>, section <<Minor Offenses>>:
 | <<Double Touch>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Indirect Free Kick>> | icon:check[role="green"]
 | <<Attacker In Defense Area>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Indirect Free Kick>> | icon:check[role="green"]
 | <<Attacker Touches Robot In Opponent Defense Area>> skipped | <<Ball In And Out Of Play, ball in play>> | no command | icon:check[role="green"] (<<Advantage Rule>>)
-| <<Excessive Dribbling>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Indirect Free Kick>> | icon:check[role="green"]
+| <<Excessive Dribbling>> | <<Ball In And Out Of Play, ball in play>> | Goals within 2 seconds do not count, Increase <<Fouls, foul counter>> | icon:check[role="green"]
 | <<Ball Speed>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Indirect Free Kick>> | icon:check[role="green"]
 |===
 

--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -43,6 +43,8 @@ NOTE: When the ball is <<Ball In And Out Of Play, out of play>>, the more strict
 ==== Excessive Dribbling
 A robot must not <<Dribbling Device, dribble>> the ball further than 1 meter, measured linearly from the ball location where the dribbling started. A robot begins dribbling when it makes contact with the ball and stops dribbling when there is an observable separation between the ball and the robot.
 
+Breaking this rule increases the <<Fouls, foul counter> by one. No stoppage occurs. Goals within 2 seconds from the end of the offense do not count.
+
 NOTE: Dribblers can still be used to dribble large distances with the ball as long as the robot periodically loses possession, such as kicking the ball ahead of it as human soccer players often do.
 
 ==== Ball Speed

--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -4,7 +4,15 @@ Offenses are divided into multiple categories according to the seriousness of th
 NOTE: Rule of thumb: Minor offenses are infringements of the rules committed by an attacking robot while the ball is <<Ball In And Out Of Play, in play>>. Fouls are infringements of the rules committed by a defender or while the ball is <<Ball In And Out Of Play, out of play>> or infringements that may harm the humans, the robots or the field.
 
 === Minor Offenses
-Minor offenses are violations of the rules that result in a stoppage and a subsequent <<Indirect Free Kick, indirect free kick>> for the opposing team. The free kick will be shot from the position where the offense began happening (see <<Direct Free Kick, the direct free kick rules>> for the exact ball position rules).
+
+Minor offenses are violations of the rules, generally by the attacking team. They result in two broad classes of penalty:
+
+  - <<Fouls, Foul counter increase>>
+  - Stoppage and subsequent <<Indirect Free Kick, indirect free kick>> for the opposing team.
+
+In the case of an <<Indirect Free Kick, indirect free kick>>, the free kick will be shot from the position where the offense began happening (see <Direct Free Kick, the direct free kick rules>> for the exact ball position rules).
+
+If the offense does not stop the game, then goals will not be counted for some duration from the end of the offense. This will reduce unnecessary stoppage, keeping the game fluid, while simultaneously not incentivizing teams to trade fouls for goals.
 
 All minor offenses are listed below.
 


### PR DESCRIPTION
No stoppage occurs. Increase foul counter. Goals within 2 seconds of end of offense do not count.

See https://docs.google.com/spreadsheets/d/1LfNNrE4ld0IkRGXSkKSKOnPDipdKbuH-InZJY2kATs4/edit?usp=sharing