### PR TITLE
Resume at the location of the ball when play is stopped after foul

### DIFF
--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -4,7 +4,7 @@ Offenses are divided into multiple categories according to the seriousness of th
 NOTE: Rule of thumb: Minor offenses are infringements of the rules committed by an attacking robot while the ball is <<Ball In And Out Of Play, in play>>. Fouls are infringements of the rules committed by a defender or while the ball is <<Ball In And Out Of Play, out of play>> or infringements that may harm the humans, the robots or the field.
 
 === Minor Offenses
-Minor offenses are violations of the rules that result in a stoppage and a subsequent <<Indirect Free Kick, indirect free kick>> for the opposing team. The free kick will be shot from the position where the offense began happening (see <<Direct Free Kick, the direct free kick rules>> for the exact ball position rules).
+Minor offenses are violations of the rules that result in a stoppage and a subsequent <<Indirect Free Kick, indirect free kick>> for the opposing team. The free kick will be shot from the position where the ball was located when the offense began happening (see <<Direct Free Kick, the direct free kick rules>> for the exact ball position rules).
 
 All minor offenses are listed below.
 
@@ -41,7 +41,7 @@ NOTE: Dribblers can still be used to dribble large distances with the ball as lo
 A robot must not accelerate the ball faster than 6.5 meters per second in 3D space.
 
 === Fouls
-Fouls are violations of the rules that result in a <<Direct Free Kick, direct free kick>> for the opposing team. The free kick will be shot from the position where the offense began happening (see <<Direct Free Kick, the direct free kick rules>> for the exact ball position rules). If the foul happened while the ball is <<Ball In And Out Of Play, out of play>>, no free kick is given.
+Fouls are violations of the rules that result in a <<Direct Free Kick, direct free kick>> for the opposing team. The free kick will be shot from the position where the ball was located when the offense began happening (see <<Direct Free Kick, the direct free kick rules>> for the exact ball position rules). If the foul happened while the ball is <<Ball In And Out Of Play, out of play>>, no free kick is given.
 
 Every third foul of the same team results in a <<Yellow Card, yellow card>>.
 


### PR DESCRIPTION
A rule change proposal discussed in the Open Meeting at last RoboCup and announced in one of the announcement mails was:

> In the event that play is stopped because of a foul (for example due to a bot collision), play will resume at the location of the ball when play is stopped (current rules resume play at the site of the offense).

This PR implements this proposal