### PR TITLE
Restructure fouls and offenses sections

### DIFF
--- a/chapters/appendix.adoc
+++ b/chapters/appendix.adoc
@@ -47,7 +47,7 @@ Chapter <<Scoring Goals>>:
 | Invalid Goal | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Free Kick>> | icon:check[role="green"]
 |===
 
-Chapter <<Rule Violations>>, section <<Stopping Offenses>>:
+Chapter <<Offenses>>, section <<Stopping Offenses>>:
 |===
 | Event | Applicability | Command | AutoRef
 
@@ -59,7 +59,7 @@ Chapter <<Rule Violations>>, section <<Stopping Offenses>>:
 |===
 
 
-Chapter <<Rule Violations>>, section <<Stopping Fouls>>:
+Chapter <<Offenses>>, section <<Stopping Fouls>>:
 |===
 | Event | Applicability | Command | AutoRef
 
@@ -74,7 +74,7 @@ Chapter <<Rule Violations>>, section <<Stopping Fouls>>:
 |===
 
 
-Chapter <<Rule Violations>>, section <<No Stop Fouls>>:
+Chapter <<Offenses>>, section <<No Stop Fouls>>:
 
 |===
 | Event | Applicability | Command | AutoRef
@@ -89,7 +89,7 @@ Chapter <<Rule Violations>>, section <<No Stop Fouls>>:
 | <<Crashing>> draw | always | no command | icon:check[role="green"]
 |===
 
-Chapter <<Rule Violations>>, section <<General Violations>>:
+Chapter <<Offenses>>, section <<General Violations>>:
 
 |===
 | Event | Applicability | Command | AutoRef

--- a/chapters/appendix.adoc
+++ b/chapters/appendix.adoc
@@ -70,23 +70,24 @@ Chapter <<Rule Violations>>, section <<Stopping Offenses>>:
 Chapter <<Reul Violations>>, section <<Stopping Fouls>>:
 |===
 | Event | Applicability | Command | AutoRef
-| Multiple <<Fouls>> | <<Ball In And Out Of Play, ball out of play>> |
-  <<Yellow Card>> | icon:times[role="red"] (handled by the game
-  controller)
-| <<Robot Too Close To Opponent Defense Area>> | <<Ball In And Out Of Play, ball out of play>> | <<Stop>>, then <<Free Kick>> | icon:check[role="green"]
+
+| <<Robot Too Close To Opponent Defense Area>> | during <<Stop>> and <<Free Kick>> | <<Stop>>, then <<Free Kick>> | icon:check[role="green"]
 | <<Pushing>> | always | <<Stop>>, then <<Free Kick>> | icon:times[role="red"]
 | <<Ball Holding>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Free Kick>> | icon:check[role="green"]
 | <<Tipping Over Or Dropping Parts>> | always | <<Stop>>, then <<Free Kick>> | icon:times[role="red"]
 | <<Robot Stop Speed>> | during <<Stop>> | <<Stop>>, then <<Free Kick>> | icon:check[role="green"]
 | <<Multiple Defenders>> partially | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Free Kick>>, <<Yellow Card>> | icon:check[role="green"]
 | <<Multiple Defenders>> entirely | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Penalty Kick>> | icon:check[role="green"]
-| <<Boundary Crossing>> | <<Ball In And Out Of Play, ball in play>> |<<Stop>> then  <<Free Kick>> | 
+| <<Boundary Crossing>> | <<Ball In And Out Of Play, ball in play>> |<<Stop>> then  <<Free Kick>> |
 |===
 
 
-Chapter <<Rule Violations>> section <<No Stop Fouls>>:
+Chapter <<Rule Violations>>, section <<No Stop Fouls>>:
 
 |===
+| Event | Applicability | Command | AutoRef
+
+| Multiple <<Fouls>> | <<Ball In And Out Of Play, ball out of play>> | <<Yellow Card>> | icon:times[role="red"] (handled by the game controller)
 | <<Attacker In Defense Area>> | <<Ball In And Out Of Play, ball in play>> | <<No Stop Fouls, No goal timer>> increase | icon:check[role="green"]
 | <<Attacker Touches Robot In Opponent Defense Area>> skipped | <<Ball In And Out Of Play, ball in play>> | <<No Stop Fouls, No goal timer>> increase | icon:check[role="green"]
 | <<Excessive Dribbling>> | <<Ball In And Out Of Play, ball in play>> | <<No Stop Fouls, No goal timer>> increase| icon:check[role="green"]
@@ -96,7 +97,7 @@ Chapter <<Rule Violations>> section <<No Stop Fouls>>:
 | <<Crashing>> draw | always | no command | icon:check[role="green"]
 |===
 
-Chapter <<Offenses>>, section <<Unsporting Behavior>>:
+Chapter <<Rule Violations>>, section <<General Violations>>:
 
 |===
 | Event | Applicability | Command | AutoRef

--- a/chapters/appendix.adoc
+++ b/chapters/appendix.adoc
@@ -58,7 +58,7 @@ NOTE: Note that the information shown in this table here is incomplete. Please r
 === Events For Stopping Fouls
 All <<Stopping Fouls>> result in:
 
-* Incrementing the foul counter.
+* Incrementing the foul counter (except for <<Multiple Defenders>>).
 
 |===
 | Event | Applicability | Action | Handled By
@@ -67,10 +67,10 @@ All <<Stopping Fouls>> result in:
 | <<Pushing>> | always | <<Stop>> -> <<Free Kick>> | referee -> game controller
 | <<Ball Holding>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>> -> <<Free Kick>> | referee -> game controller
 | <<Tipping Over Or Dropping Parts>> | always | <<Stop>> -> <<Free Kick>> | referee -> game controller
-| <<Multiple Defenders>> partially | <<Ball In And Out Of Play, ball in play>> | <<Stop>> -> <<Yellow Card>> -> <<Free Kick>> | auto referee
-| <<Multiple Defenders>> entirely | <<Ball In And Out Of Play, ball in play>> | <<Stop>> -> <<Penalty Kick>> | auto referee
+| <<Multiple Defenders>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>> -> <<Penalty Kick>> | auto referee
 | <<Boundary Crossing>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>> -> <<Free Kick>> | auto referee
 | <<Keeper Held Ball>> in <<Defense Area, defense area>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>> -> <<Free Kick>> | auto referee
+| <<Excessive Dribbling>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>> -> <<Free Kick>> | auto referee
 |===
 
 
@@ -78,13 +78,12 @@ All <<Stopping Fouls>> result in:
 All <<Non Stopping Fouls>> result in:
 
 * Incrementing the foul counter.
-* Increasing the no goal timer.
+* Repeated every 2 seconds, if still committed without interruption.
 
 |===
 | Event | Applicability | Action | Handled By
 
-| <<Attacker In Defense Area>> | <<Ball In And Out Of Play, ball in play>> | - | auto referee
-| <<Excessive Dribbling>> | <<Ball In And Out Of Play, ball in play>> | - | auto referee
+| <<Attacker Touched Ball In Opponent Defense Area>> | <<Ball In And Out Of Play, ball in play>> | - | auto referee
 | <<Ball Speed>> | <<Ball In And Out Of Play, ball in play>> | - | auto referee
 | <<Attacker Touches Robot In Opponent Defense Area>> | <<Ball In And Out Of Play, ball in play>> | - | auto referee
 | <<Crashing>> | always | - | auto referee

--- a/chapters/appendix.adoc
+++ b/chapters/appendix.adoc
@@ -30,7 +30,7 @@ NOTE: Note that the information shown in this table here is incomplete. Please r
 | <<Throw-In>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>> -> <<Free Kick>> | auto referee
 | <<Goal Kick>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>> -> <<Free Kick>> | auto referee
 | <<Corner Kick>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>> -> <<Free Kick>> | auto referee
-| <<Aimless Kick [small]#(_division B only_)#, Aimless Kick>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>> -> <<Free Kick>> | auto referee
+| <<aimless-kick>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>> -> <<Free Kick>> | auto referee
 |===
 
 
@@ -117,5 +117,5 @@ This is a complete list of differences between <<Divisions, division>> A and <<D
 * Division A plays on a <<Dimensions, larger field>> with <<Goals, larger goals>> than division B. As a result, the <<Shoot-Out, shoot-out>> is taken from a greater distance as well.
 * Division A plays with <<Number Of Robots, more robots>> than division B.
 * The automatic <<Ball Placement, ball placement>> procedure is mandatory for division A and optional for division B.
-* The <<Aimless Kick [small]#(_Division B only_)#, aimless kick>> rule only applies to division B.
+* The <<aimless-kick, aimless kick>> rule only applies to division B.
 * Division A has shorter timeouts in some situations

--- a/chapters/appendix.adoc
+++ b/chapters/appendix.adoc
@@ -47,11 +47,11 @@ NOTE: Note that the information shown in this table here is incomplete. Please r
 |===
 | Event | Applicability | Command | Handled By
 
-| Multiple <<Yellow Card, Yellow Cards>> | always | <<Read Card>> | game controller
 | <<No Progress In Game>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>> -> <<Force Start>> | auto referee
 | <<Double Touch>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>> -> <<Free Kick>> | auto referee
-| Multiple <<Fouls>> | always | <<Yellow Card>> | game controller
 | <<Unsporting Behavior>> | always | <<Stop>> -> <<Yellow Card>>, <<Red Card>>, <<Penalty Kick>>, <<Forced Forfeit>> or <<Disqualification>> | referee -> game controller
+| Multiple <<Fouls>> | always | <<Yellow Card>> | game controller
+| Multiple <<Yellow Card, Yellow Cards>> | always | <<Red Card>> | game controller
 |===
 
 

--- a/chapters/appendix.adoc
+++ b/chapters/appendix.adoc
@@ -1,13 +1,5 @@
 [appendix]
 == Terminology
-=== Ball In And Out Of Play
-When the match is <<Stopping The Game, stopped>>, the ball is considered *out of play* until it has been brought into play.
-
-When the match is <<Resuming The Game, resumed>>, the ball is considered *in play* until the next stoppage occurs. The match is resumed when <<Force Start, force start>> has been issued or the ball moved at least 0.05 meters following a <<Kick-Off, kick-off>>, <<Free Kick, free kick>> or <<Penalty Kick, penalty kick>>.
-
-NOTE: see <<Double Touch, double touch>> for the rationale of the 0.05 meter distance
-
-
 === Ball Manipulation
 Shooting and <<Dribbling Device, dribbling>> is considered as manipulating the ball, the ball accidentally bouncing off the hull is not.
 

--- a/chapters/appendix.adoc
+++ b/chapters/appendix.adoc
@@ -74,8 +74,8 @@ All <<Stopping Fouls>> result in:
 |===
 
 
-=== Events For No Stop Fouls
-All <<No Stop Fouls>> result in:
+=== Events For Non Stopping Fouls
+All <<Non Stopping Fouls>> result in:
 
 * Incrementing the foul counter.
 * Increasing the no goal timer.

--- a/chapters/appendix.adoc
+++ b/chapters/appendix.adoc
@@ -86,10 +86,23 @@ All <<Non Stopping Fouls>> result in:
 | <<Attacker In Defense Area>> | <<Ball In And Out Of Play, ball in play>> | - | auto referee
 | <<Excessive Dribbling>> | <<Ball In And Out Of Play, ball in play>> | - | auto referee
 | <<Ball Speed>> | <<Ball In And Out Of Play, ball in play>> | - | auto referee
-| <<Defender Too Close To Ball>> | <<Ball In And Out Of Play, ball out of play>> | - | auto referee
 | <<Attacker Touches Robot In Opponent Defense Area>> | <<Ball In And Out Of Play, ball in play>> | - | auto referee
 | <<Crashing>> | always | - | auto referee
 | <<Crashing>> draw | always | - | auto referee
+|===
+
+
+=== Events For Fouls While Ball Out Of Play
+All <<Fouls While Ball Out Of Play>> result in:
+
+* Incrementing the foul counter.
+* Repeated every 2 seconds, if still committed.
+* Only once per foul, team and 2 seconds.
+
+|===
+| Event | Applicability | Action | Handled By
+
+| <<Defender Too Close To Ball>> | <<Ball In And Out Of Play, ball out of play>> | - | auto referee
 | <<Robot Stop Speed>> | during <<Stop>> | - | auto referee
 | <<Ball Placement Interference>> | during <<Ball Placement>> | placement timer increased by 10 seconds | auto referee
 |===

--- a/chapters/appendix.adoc
+++ b/chapters/appendix.adoc
@@ -30,7 +30,7 @@ NOTE: Note that the information shown in this table here is incomplete. Please r
 | <<Throw-In>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>> -> <<Free Kick>> | auto referee
 | <<Goal Kick>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>> -> <<Free Kick>> | auto referee
 | <<Corner Kick>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>> -> <<Free Kick>> | auto referee
-| <<aimless-kick>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>> -> <<Free Kick>> | auto referee
+| <<aimless-kick, Aimless Kick>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>> -> <<Free Kick>> | auto referee
 |===
 
 
@@ -47,11 +47,11 @@ NOTE: Note that the information shown in this table here is incomplete. Please r
 |===
 | Event | Applicability | Command | Handled By
 
-| Multiple <<Yellow Card, Yellow Cards>> | <<Ball In And Out Of Play, ball out of play>> | <<Stop>> -> <<Penalty Kick>> | game controller
+| Multiple <<Yellow Card, Yellow Cards>> | always | <<Stop>> -> <<Penalty Kick>> | game controller
 | <<No Progress In Game>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>> -> <<Force Start>> | auto referee
 | <<Double Touch>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>> -> <<Free Kick>> | auto referee
-| Multiple <<Fouls>> | <<Ball In And Out Of Play, ball out of play>> | <<Yellow Card>> | game controller
-| Unsporting Behavior | always | <<Stop>> -> <<Yellow Card>>, <<Red Card>>, <<Penalty Kick>>, <<Forced Forfeit>> or <<Disqualification>> | referee -> game controller
+| Multiple <<Fouls>> | always | <<Yellow Card>> | game controller
+| <<Unsporting Behavior>> | always | <<Stop>> -> <<Yellow Card>>, <<Red Card>>, <<Penalty Kick>>, <<Forced Forfeit>> or <<Disqualification>> | referee -> game controller
 |===
 
 

--- a/chapters/appendix.adoc
+++ b/chapters/appendix.adoc
@@ -10,99 +10,104 @@ The game event table is a compilation of the different game events and their con
 
 NOTE: Note that the information shown in this table here is incomplete. Please read the sections of the respective events for the full definitions.
 
-Chapter <<Robots>>:
+=== Events For Match Proceeding
 |===
-| Event | Applicability | Command | AutoRef
+| Event | Applicability | Command | Handled By
 
-| <<Number Of Robots>> exceeded | always | <<Stop>> | icon:check[role="green"]
-|===
-
-Chapter <<Referee Commands>>:
-|===
-| Event | Applicability | Command | AutoRef
-
-| <<Kick-Off>> prepared | during <<Kick-Off>> | <<Normal Start>> | icon:check[role="green"]
-| No Progress | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Force Start>> | icon:check[role="green"]
-| <<Penalty Kick>> prepared | during <<Penalty Kick>> | <<Normal Start>> | icon:check[role="green"]
-| Multiple <<Yellow Card, Yellow Cards>> | <<Ball In And Out Of Play, ball out of play>> | <<Penalty Kick>> | icon:times[role="red"] (handled by the game controller)
-| <<Ball Placement>> failed by team in favor | during <<Ball Placement>> | <<Stop>>, then <<Free Kick>> (div A) / previous command (div B) | icon:check[role="green"]
-| <<Ball Placement>> failed by opponent | during <<Ball Placement>> | <<Stop>> | icon:check[role="green"]
-| <<Ball Placement>> successful | during <<Ball Placement>> | continue | icon:check[role="green"]
-|===
-
-Chapter <<Ball Leaves The Field>>:
-|===
-| Event | Applicability | Command | AutoRef
-
-| <<Throw-In>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Free Kick>> | icon:check[role="green"]
-| <<Goal Kick>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Free Kick>> | icon:check[role="green"]
-| <<Corner Kick>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Free Kick>> | icon:check[role="green"]
-|===
-
-Chapter <<Scoring Goals>>:
-|===
-| Event | Applicability | Command | AutoRef
-
-| Goal | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Kick-Off>> | (icon:check[role="green"]) footnote:[the game controller operator has to continue the game]
-| Invalid Goal | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Free Kick>> | icon:check[role="green"]
-|===
-
-Chapter <<Offenses>>, section <<Stopping Offenses>>:
-|===
-| Event | Applicability | Command | AutoRef
-
-| <<Aimless Kick [small]#(_division B only_)#, Aimless Kick>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Free Kick>> | icon:check[role="green"]
-| <<Lack Of Progress>> during <<Kick-Off>>, <<Free Kick>> | <<Ball In And Out Of Play, ball in play>> | Ball is considered in-play and manipulable by both teams | icon:check[role="green"]
-| <<Lack Of Progress>> ball in <<Defense Area, defense area>> | <<Ball In And Out Of Play, ball in play>> | <<Free Kick, free kick>> | icon:check[role="green"]
-| <<Lack Of Progress>>, otherwise | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Force Start>> | icon:check[role="green"]
-| <<Double Touch>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Free Kick>> | icon:check[role="green"]
+| Prepared | during <<Kick-Off>>, <<Penalty Kick>> | <<Normal Start>> | auto referee
+| <<Ball Placement>> failed by team in favor | during <<Ball Placement>> | <<Stop>> -> <<Free Kick>> (div A) / previous command (div B) | auto referee
+| <<Ball Placement>> failed by opponent | during <<Ball Placement>> | <<Stop>> | auto referee
+| <<Ball Placement>> successful | during <<Ball Placement>> | continue | auto referee
+| <<Robot Substitution>> Intent | always | <<Halt>> (after next stoppage), then <<Stop>> | game controller
+| <<Number Of Robots>> exceeded | always | <<Stop>> | auto referee
 |===
 
 
-Chapter <<Offenses>>, section <<Stopping Fouls>>:
+=== Events For Ball Leaving The Field
 |===
-| Event | Applicability | Command | AutoRef
+| Event | Applicability | Command | Handled By
 
-| <<Robot Too Close To Opponent Defense Area>> | during <<Stop>> and <<Free Kick>> | <<Stop>>, then <<Free Kick>> | icon:check[role="green"]
-| <<Pushing>> | always | <<Stop>>, then <<Free Kick>> | icon:times[role="red"]
-| <<Ball Holding>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Free Kick>> | icon:times[role="red"]
-| <<Tipping Over Or Dropping Parts>> | always | <<Stop>>, then <<Free Kick>> | icon:times[role="red"]
-| <<Robot Stop Speed>> | during <<Stop>> | <<Stop>>, then <<Free Kick>> | icon:check[role="green"]
-| <<Multiple Defenders>> partially | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Free Kick>>, <<Yellow Card>> | icon:check[role="green"]
-| <<Multiple Defenders>> entirely | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Penalty Kick>> | icon:check[role="green"]
-| <<Boundary Crossing>> | <<Ball In And Out Of Play, ball in play>> |<<Stop>> then  <<Free Kick>> |
+| <<Throw-In>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>> -> <<Free Kick>> | auto referee
+| <<Goal Kick>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>> -> <<Free Kick>> | auto referee
+| <<Corner Kick>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>> -> <<Free Kick>> | auto referee
+| <<Aimless Kick [small]#(_division B only_)#, Aimless Kick>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>> -> <<Free Kick>> | auto referee
 |===
 
 
-Chapter <<Offenses>>, section <<No Stop Fouls>>:
-
+=== Events For Scoring Goals
 |===
-| Event | Applicability | Command | AutoRef
+| Event | Applicability | Command | Handled By
 
-| Multiple <<Fouls>> | <<Ball In And Out Of Play, ball out of play>> | <<Yellow Card>> | icon:times[role="red"] (handled by the game controller)
-| <<Attacker In Defense Area>> | <<Ball In And Out Of Play, ball in play>> | <<No Stop Fouls, No goal timer>> increase | icon:check[role="green"]
-| <<Attacker Touches Robot In Opponent Defense Area>> skipped | <<Ball In And Out Of Play, ball in play>> | <<No Stop Fouls, No goal timer>> increase | icon:check[role="green"]
-| <<Excessive Dribbling>> | <<Ball In And Out Of Play, ball in play>> | <<No Stop Fouls, No goal timer>> increase| icon:check[role="green"]
-| <<Ball Speed>> | <<Ball In And Out Of Play, ball in play>> | <<No Stop Fouls, No goal timer>> increase| icon:check[role="green"]
-| <<Defender Too Close To Ball>> | <<Ball In And Out Of Play, ball out of play>> | <<No Stop Fouls, No goal timer>> increase | icon:check[role="green"]
-| <<Crashing>> | always | <<No Stop Fouls, No goal timer>> increase | icon:check[role="green"]
-| <<Crashing>> draw | always | no command | icon:check[role="green"]
+| <<Scoring Goals, Goal>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>> -> <<Kick-Off>> | (auto referee) footnote:[the game controller operator has to continue the game]
+| <<Scoring Goals, Invalid Goal>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>> -> <<Free Kick>> | auto referee
 |===
 
-Chapter <<Offenses>>, section <<General Violations>>:
+
+=== Events For Offenses
+|===
+| Event | Applicability | Command | Handled By
+
+| Multiple <<Yellow Card, Yellow Cards>> | <<Ball In And Out Of Play, ball out of play>> | <<Stop>> -> <<Penalty Kick>> | game controller
+| <<No Progress In Game>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>> -> <<Force Start>> | auto referee
+| <<Double Touch>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>> -> <<Free Kick>> | auto referee
+| Multiple <<Fouls>> | <<Ball In And Out Of Play, ball out of play>> | <<Yellow Card>> | game controller
+| Unsporting Behavior | always | <<Stop>> -> <<Yellow Card>>, <<Red Card>>, <<Penalty Kick>>, <<Forced Forfeit>> or <<Disqualification>> | referee -> game controller
+|===
+
+
+=== Events For Stopping Fouls
+All <<Stopping Fouls>> result in:
+
+* Incrementing the foul counter.
 
 |===
-| Event | Applicability | Command | AutoRef
+| Event | Applicability | Action | Handled By
 
-| Unsporting Behavior | always | <<Stop>>, then <<Yellow Card>>, <<Red Card>>, <<Penalty Kick>>, <<Forced Forfeit>> or <<Disqualification>> | icon:times[role="red"]
+| <<Robot Too Close To Opponent Defense Area>> | during <<Stop>> and <<Free Kick>> | <<Stop>> -> <<Free Kick>> | auto referee
+| <<Pushing>> | always | <<Stop>> -> <<Free Kick>> | referee -> game controller
+| <<Ball Holding>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>> -> <<Free Kick>> | referee -> game controller
+| <<Tipping Over Or Dropping Parts>> | always | <<Stop>> -> <<Free Kick>> | referee -> game controller
+| <<Multiple Defenders>> partially | <<Ball In And Out Of Play, ball in play>> | <<Stop>> -> <<Yellow Card>> -> <<Free Kick>> | auto referee
+| <<Multiple Defenders>> entirely | <<Ball In And Out Of Play, ball in play>> | <<Stop>> -> <<Penalty Kick>> | auto referee
+| <<Boundary Crossing>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>> -> <<Free Kick>> | auto referee
+| <<Keeper Held Ball>> in <<Defense Area, defense area>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>> -> <<Free Kick>> | auto referee
 |===
 
-Chapter <<Robot Substitution>>:
-|===
-| Event | Applicability | Command | AutoRef
 
-| <<Robot Substitution>> Intent | always | <<Halt>> (after next stoppage), then <<Stop>> | icon:times[role="red"]
+=== Events For No Stop Fouls
+All <<No Stop Fouls>> result in:
+
+* Incrementing the foul counter.
+* Increasing the no goal timer.
+
 |===
+| Event | Applicability | Action | Handled By
+
+| <<Attacker In Defense Area>> | <<Ball In And Out Of Play, ball in play>> | - | auto referee
+| <<Excessive Dribbling>> | <<Ball In And Out Of Play, ball in play>> | - | auto referee
+| <<Ball Speed>> | <<Ball In And Out Of Play, ball in play>> | - | auto referee
+| <<Defender Too Close To Ball>> | <<Ball In And Out Of Play, ball out of play>> | - | auto referee
+| <<Attacker Touches Robot In Opponent Defense Area>> | <<Ball In And Out Of Play, ball in play>> | - | auto referee
+| <<Crashing>> | always | - | auto referee
+| <<Crashing>> draw | always | - | auto referee
+| <<Robot Stop Speed>> | during <<Stop>> | - | auto referee
+| <<Ball Placement Interference>> | during <<Ball Placement>> | placement timer increased by 10 seconds | auto referee
+|===
+
+
+[appendix]
+== Overview of Timings
+|===
+| Situation                                                           | Div A Time | Div B Time
+
+| Remove robot for <<Yellow Card>>                                    | 10 s       | 10 s
+| <<Penalty Kick, penalty kick>>                                      | 10 s       | 10 s
+| <<Kick-Off, kick-off>>                                              | 10 s       | 10 s
+| <<Free Kick, free kick>>                                            |  5 s       | 10 s
+| <<Keeper Held Ball>> inside <<Defense Area>>                        |  5 s       | 10 s
+| <<No Progress In Game>>                                             |  5 s       | 10 s
+|===
+
 
 [appendix]
 == Differences Between Divisions
@@ -112,6 +117,5 @@ This is a complete list of differences between <<Divisions, division>> A and <<D
 * Division A plays on a <<Dimensions, larger field>> with <<Goals, larger goals>> than division B. As a result, the <<Shoot-Out, shoot-out>> is taken from a greater distance as well.
 * Division A plays with <<Number Of Robots, more robots>> than division B.
 * The automatic <<Ball Placement, ball placement>> procedure is mandatory for division A and optional for division B.
-* The <<Aimless Kick [small]#(_division B only_)#, aimless kick>> rule only applies to division B.
-* There is a smaller time window in division A for taking a free kick before <<Lack Of Progress, lack of progress>> is called.
-* Division A has a shorter <<Lack Of Progress, lack of progress>> timeout in some situations
+* The <<Aimless Kick [small]#(_Division B only_)#, aimless kick>> rule only applies to division B.
+* Division A has shorter timeouts in some situations

--- a/chapters/appendix.adoc
+++ b/chapters/appendix.adoc
@@ -65,7 +65,7 @@ Chapter <<Rule Violations>>, section <<Stopping Fouls>>:
 
 | <<Robot Too Close To Opponent Defense Area>> | during <<Stop>> and <<Free Kick>> | <<Stop>>, then <<Free Kick>> | icon:check[role="green"]
 | <<Pushing>> | always | <<Stop>>, then <<Free Kick>> | icon:times[role="red"]
-| <<Ball Holding>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Free Kick>> | icon:check[role="green"]
+| <<Ball Holding>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Free Kick>> | icon:times[role="red"]
 | <<Tipping Over Or Dropping Parts>> | always | <<Stop>>, then <<Free Kick>> | icon:times[role="red"]
 | <<Robot Stop Speed>> | during <<Stop>> | <<Stop>>, then <<Free Kick>> | icon:check[role="green"]
 | <<Multiple Defenders>> partially | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Free Kick>>, <<Yellow Card>> | icon:check[role="green"]

--- a/chapters/appendix.adoc
+++ b/chapters/appendix.adoc
@@ -55,38 +55,45 @@ Chapter <<Scoring Goals>>:
 | Invalid Goal | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Free Kick>> | icon:check[role="green"]
 |===
 
-Chapter <<Offenses>>, section <<Minor Offenses>>:
+Chapter <<Rule Violations>>, section <<Stopping Offenses>>:
 |===
 | Event | Applicability | Command | AutoRef
 
 | <<Aimless Kick [small]#(_division B only_)#, Aimless Kick>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Free Kick>> | icon:check[role="green"]
-| <<Lack Of Progress>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Free Kick>> | icon:check[role="green"]
+| <<Lack Of Progress>> during <<Kick-Off>>, <<Free Kick>> | <<Ball In And Out Of Play, ball in play>> | Ball is considered in-play and manipulatable by both teams | icon:check[role="green"]
+| <<Lack Of Progress>> ball in <<Defense Area, defense area>> | <<Ball In And Out Of Play, ball in play>> | <<Indirect Free Kick, indirect free kick>> | icon:check[role="green"]
+| <<Lack Of Progress>>, otherwise | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Force Start>> | icon:check[role="green"]
 | <<Double Touch>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Free Kick>> | icon:check[role="green"]
-| <<Attacker In Defense Area>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Free Kick>> | icon:check[role="green"]
-| <<Attacker Touches Robot In Opponent Defense Area>> skipped | <<Ball In And Out Of Play, ball in play>> | no command | icon:check[role="green"] (<<Advantage Rule>>)
-| <<Excessive Dribbling>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Free Kick>> | icon:check[role="green"]
-| <<Ball Speed>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Free Kick>> | icon:check[role="green"]
 |===
 
 
-Chapter <<Offenses>>, section <<Fouls>>:
+Chapter <<Reul Violations>>, section <<Stopping Fouls>>:
 |===
 | Event | Applicability | Command | AutoRef
-
-| Multiple <<Fouls>> | <<Ball In And Out Of Play, ball out of play>> | <<Yellow Card>> | icon:times[role="red"] (handled by the game controller)
-| <<Attacker Touches Robot In Opponent Defense Area>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Free Kick>> | icon:check[role="green"]
+| Multiple <<Fouls>> | <<Ball In And Out Of Play, ball out of play>> |
+  <<Yellow Card>> | icon:times[role="red"] (handled by the game
+  controller)
 | <<Robot Too Close To Opponent Defense Area>> | <<Ball In And Out Of Play, ball out of play>> | <<Stop>>, then <<Free Kick>> | icon:check[role="green"]
-| <<Ball Placement Interference>> | during <<Ball Placement>> | <<Stop>>, then <<Free Kick>> | icon:check[role="green"]
-| <<Crashing>> | always | <<Stop>>, then <<Free Kick>> | icon:check[role="green"]
-| <<Crashing>> skipped | always | no command | icon:check[role="green"] (<<Advantage Rule>>)
-| <<Crashing>> draw | always | no command | icon:check[role="green"]
 | <<Pushing>> | always | <<Stop>>, then <<Free Kick>> | icon:times[role="red"]
 | <<Ball Holding>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Free Kick>> | icon:check[role="green"]
 | <<Tipping Over Or Dropping Parts>> | always | <<Stop>>, then <<Free Kick>> | icon:times[role="red"]
 | <<Robot Stop Speed>> | during <<Stop>> | <<Stop>>, then <<Free Kick>> | icon:check[role="green"]
-| <<Defender Too Close To Ball>> | <<Ball In And Out Of Play, ball out of play>> | <<Stop>>, then <<Free Kick>> | icon:check[role="green"]
 | <<Multiple Defenders>> partially | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Free Kick>>, <<Yellow Card>> | icon:check[role="green"]
 | <<Multiple Defenders>> entirely | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Penalty Kick>> | icon:check[role="green"]
+| <<Boundary Crossing>> | <<Ball In And Out Of Play, ball in play>> |<<Stop>> then  <<Free Kick>> | 
+|===
+
+
+Chapter <<Rule Violations>> section <<No Stop Fouls>>:
+
+|===
+| <<Attacker In Defense Area>> | <<Ball In And Out Of Play, ball in play>> | <<No Stop Fouls, No goal timer>> increase | icon:check[role="green"]
+| <<Attacker Touches Robot In Opponent Defense Area>> skipped | <<Ball In And Out Of Play, ball in play>> | <<No Stop Fouls, No goal timer>> increase | icon:check[role="green"]
+| <<Excessive Dribbling>> | <<Ball In And Out Of Play, ball in play>> | <<No Stop Fouls, No goal timer>> increase| icon:check[role="green"]
+| <<Ball Speed>> | <<Ball In And Out Of Play, ball in play>> | <<No Stop Fouls, No goal timer>> increase| icon:check[role="green"]
+| <<Defender Too Close To Ball>> | <<Ball In And Out Of Play, ball out of play>> | <<No Stop Fouls, No goal timer>> increase | icon:check[role="green"]
+| <<Crashing>> | always | <<No Stop Fouls, No goal timer>> increase | icon:check[role="green"]
+| <<Crashing>> draw | always | no command | icon:check[role="green"]
 |===
 
 Chapter <<Offenses>>, section <<Unsporting Behavior>>:
@@ -114,3 +121,4 @@ This is a complete list of differences between <<Divisions, division>> A and <<D
 * The automatic <<Ball Placement, ball placement>> procedure is mandatory for division A and optional for division B.
 * The <<Aimless Kick [small]#(_division B only_)#, aimless kick>> rule only applies to division B.
 * There is a smaller time window in division A for taking a free kick before <<Lack Of Progress, lack of progress>> is called.
+* Division A has a shorter <<Lack Of Progress, lack of progress>> timeout in some situations

--- a/chapters/appendix.adoc
+++ b/chapters/appendix.adoc
@@ -67,7 +67,7 @@ Chapter <<Rule Violations>>, section <<Stopping Offenses>>:
 |===
 
 
-Chapter <<Reul Violations>>, section <<Stopping Fouls>>:
+Chapter <<Rule Violations>>, section <<Stopping Fouls>>:
 |===
 | Event | Applicability | Command | AutoRef
 

--- a/chapters/appendix.adoc
+++ b/chapters/appendix.adoc
@@ -85,7 +85,6 @@ All <<Non Stopping Fouls>> result in:
 
 | <<Attacker Touched Ball In Opponent Defense Area>> | <<Ball In And Out Of Play, ball in play>> | - | auto referee
 | <<Ball Speed>> | <<Ball In And Out Of Play, ball in play>> | - | auto referee
-| <<Attacker Touches Robot In Opponent Defense Area>> | <<Ball In And Out Of Play, ball in play>> | - | auto referee
 | <<Crashing>> | always | - | auto referee
 | <<Crashing>> draw | always | - | auto referee
 |===

--- a/chapters/appendix.adoc
+++ b/chapters/appendix.adoc
@@ -60,8 +60,8 @@ Chapter <<Rule Violations>>, section <<Stopping Offenses>>:
 | Event | Applicability | Command | AutoRef
 
 | <<Aimless Kick [small]#(_division B only_)#, Aimless Kick>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Free Kick>> | icon:check[role="green"]
-| <<Lack Of Progress>> during <<Kick-Off>>, <<Free Kick>> | <<Ball In And Out Of Play, ball in play>> | Ball is considered in-play and manipulatable by both teams | icon:check[role="green"]
-| <<Lack Of Progress>> ball in <<Defense Area, defense area>> | <<Ball In And Out Of Play, ball in play>> | <<Indirect Free Kick, indirect free kick>> | icon:check[role="green"]
+| <<Lack Of Progress>> during <<Kick-Off>>, <<Free Kick>> | <<Ball In And Out Of Play, ball in play>> | Ball is considered in-play and manipulable by both teams | icon:check[role="green"]
+| <<Lack Of Progress>> ball in <<Defense Area, defense area>> | <<Ball In And Out Of Play, ball in play>> | <<Free Kick, free kick>> | icon:check[role="green"]
 | <<Lack Of Progress>>, otherwise | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Force Start>> | icon:check[role="green"]
 | <<Double Touch>> | <<Ball In And Out Of Play, ball in play>> | <<Stop>>, then <<Free Kick>> | icon:check[role="green"]
 |===

--- a/chapters/ballleavesthefield.adoc
+++ b/chapters/ballleavesthefield.adoc
@@ -35,3 +35,14 @@ After the ball has been placed, a <<Free Kick, free kick>> is awarded to the opp
 
 .Usage
 A corner kick is used to restart the game after the ball left the field by crossing the goal line of the team that touched the ball last.
+
+==== Aimless Kick [small]#(_Division B only_)#
+.Definition
+The ball has to be placed at the position from where the ball was kicked (see the <<Free Kick, free kick>> rules for the exact ball position rules).
+
+After the ball has been placed, a <<Free Kick, free kick>> is awarded to the opponent of the team that last touched the ball before it left the field.
+
+.Usage
+A kick is aimless when after the ball touched a robot, it subsequently crossed the midline and then its opponent's goal line outside the goal without touching another robot.
+
+A kick-off kick cannot be aimless, as the ball is located at the midline and does therefore not cross it.

--- a/chapters/ballleavesthefield.adoc
+++ b/chapters/ballleavesthefield.adoc
@@ -25,7 +25,7 @@ After the ball has been placed, a <<Free Kick, free kick>> is awarded to the opp
 .Usage
 A goal kick is used to restart the game after the ball left the field by crossing the goal line of the team that did not touch the ball last.
 
-NOTE: In division B, the <<Aimless Kick [small]#(_division B only_)#, aimless kick rule>> might apply instead.
+NOTE: In division B, the <<aimless-kick, aimless kick rule>> might apply instead.
 
 ==== Corner Kick
 .Definition
@@ -36,6 +36,7 @@ After the ball has been placed, a <<Free Kick, free kick>> is awarded to the opp
 .Usage
 A corner kick is used to restart the game after the ball left the field by crossing the goal line of the team that touched the ball last.
 
+[[aimless-kick, Aimless Kick]]
 ==== Aimless Kick [small]#(_Division B only_)#
 .Definition
 The ball has to be placed at the position from where the ball was kicked (see the <<Free Kick, free kick>> rules for the exact ball position rules).

--- a/chapters/challengeflag.adoc
+++ b/chapters/challengeflag.adoc
@@ -1,4 +1,4 @@
-== Challenge Flag
+== Challenge Flags
 
 A challenge flag allows teams to challenge a decision of the referee:
 

--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -121,10 +121,6 @@ NOTE: Dribblers can still be used to dribble large distances with the ball as lo
 ===== Ball Speed
 A robot must not accelerate the ball faster than 6.5 meters per second in 3D space.
 
-The <<Referee, human referee>> may decide to repeat the <<Kick-Off, kick-off>> or <<Free Kick, free kick>> on significant disturbances.
-
-NOTE: During <<Stop, stop>>, there is no automatic sanction for being too close to the ball. The referee may still punish a team for <<Unsporting Behavior,unsporting behavior>> by issuing a <<Yellow Card, yellow card>> if it does not respect the required distance. See <<Stop, stop>> for further explanation.
-
 ===== Attacker Touches Robot In Opponent Defense Area
 When the ball is <<Ball In And Out Of Play, in play>>, a robot must not touch any opponent robot inside the opponent <<Defense Area, defense area>>.
 
@@ -145,6 +141,10 @@ NOTE: If a robot keeps committing a foul, it will be punished again after the gr
 ===== Defender Too Close To Ball
 A robot's distance to the ball must be at least 0.5 meters during an opponent <<Kick-Off, kick-off>> or <<Free Kick, free kick>>.
 While the foul is being committed, the timer of the opponent team for bringing the ball into play is reset.
+
+The <<Referee, human referee>> may decide to repeat the <<Kick-Off, kick-off>> or <<Free Kick, free kick>> on significant disturbances.
+
+NOTE: During <<Stop, stop>>, there is no automatic sanction for being too close to the ball. The referee may still punish a team for <<Unsporting Behavior,unsporting behavior>> by issuing a <<Yellow Card, yellow card>> if it does not respect the required distance. See <<Stop, stop>> for further explanation.
 
 ===== Robot Stop Speed
 A robot must not move faster than 1.5 meters per second during <<Stop, stop>>. A violation of this rule is only counted once per robot and stoppage.

--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -1,4 +1,4 @@
-== Rule Violations
+== Offenses
 === No Progress In Game
 If there is no progress in the game while both teams are allowed to
 <<Ball Manipulation, manipulate the ball>>, the game is <<Stop, stopped>>

--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -49,11 +49,9 @@ A kick is aimless when after the ball touched a robot, it subsequently crossed t
 ==== Lack Of Progress
 
 There is a lack of progress if only one team is allowed to <<Ball
-Manipulation, manipulate the ball>> (<<Kick-Off, kick-off>>, <<Direct
-Free Kick, direct free kick>>, <<Indirect Free Kick, indirect free
-kick>>) and does not bring the ball
-<<Ball In And Out Of Play, into play>> in time. The time before lack
-of progress is called is described in the table: <<lack-of-progress-timings>>.
+Manipulation, manipulate the ball>> (<<Kick-Off, kick-off>>, <<Free Kick, free kick>>)
+and does not bring the ball <<Ball In And Out Of Play, into play>> in time.
+The time before lack of progress is called is described in the table: <<lack-of-progress-timings>>.
 
 [frame="topbot",options="header"]
 .Lack Of Progress Timings
@@ -72,8 +70,7 @@ If there is a lack of progress due to the ball being inside a team's
 <<Defense Area, defense area>> past the timeout, then a <<Free
 Kick, free kick>> is issued for the attacking team.
 
-In the case of <<Kick-Off, kick-off>>, <<Direct Free Kick, direct free
-kick>>, <<Indirect Free Kick, indirect free kick>>, after the time
+In the case of <<Kick-Off, kick-off>> and <<Free Kick, free kick>>, after the time
 expires the ball is considered <<Ball In And Out Of Play, in play>>
 and both teams may manipulate the ball.
 

--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -186,6 +186,8 @@ A robot must not accelerate the ball faster than 6.5 meters per second in 3D spa
 ===== Defender Too Close To Ball
 A robot's distance to the ball must be at least 0.5 meters during an opponent <<Kick-Off, kick-off>> or <<Free Kick, free kick>>.
 
+The <<Referee, human referee>> may decide to repeat the <<Kick-Off, kick-off>> or <<Free Kick, free kick>> on significant disturbances.
+
 NOTE: During <<Stop, stop>>, there is no automatic sanction for being too close to the ball. The referee may still punish a team for <<Unsporting Behavior,unsporting behavior>> by issuing a <<Yellow Card, yellow card>> if it does not respect the required distance. See <<Stop, stop>> for further explanation.
 
 ===== Attacker Touches Robot In Opponent Defense Area

--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -133,7 +133,7 @@ NOTE: When the ball is <<Ball In And Out Of Play, out of play>>, the rule <<Robo
 ===== Crashing
 At the moment of collision of two robots of different teams, the difference of the speed vectors of both robots is taken and projected onto the line that is defined by the position of both robots. If the length of this projection is greater than 1.5 meters per second, the faster robot committed a foul. If the absolute robot speed difference is less than 0.3 meters per second, both conduct a foul.
 
-==== Fouls During Stop
+==== Fouls While Ball Out Of Play
 Fouls in this section can only occur when the ball is <<Ball In And Out Of Play, out of play>>.
 
 Each foul has a grace period of 2 seconds per team until it is raised again.

--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -54,17 +54,6 @@ A robot violating this rule has to be <<Robot Substitution, substituted>>.
 
 NOTE: Metal parts (screws for example) as well as larger parts generally pose a potential threat, very small non-metal parts (for example rubber subwheel rings) don't.
 
-===== Robot Stop Speed
-A robot must not move faster than 1.5 meters per second during <<Stop, stop>>. A violation of this rule is only counted once per robot and stoppage.
-
-There is a grace period of 2 seconds for the robots to slow down.
-
-NOTE: This rule does not apply to <<Ball Placement, ball placement>>.
-
-NOTE: Since the stop command is used for manual ball placement and
-<<Robot Substitution, robot substitution>>, the intention of the robot
-speed limit is to avoid robots harming the people on the field.
-
 ===== Multiple Defenders
 NOTE: This rule does not use the standard sanctions defined for <<Fouls, fouls>>.
 
@@ -126,6 +115,17 @@ NOTE: When the ball is <<Ball In And Out Of Play, out of play>>, the rule <<Robo
 
 ===== Crashing
 At the moment of collision of two robots of different teams, the difference of the speed vectors of both robots is taken and projected onto the line that is defined by the position of both robots. If the length of this projection is greater than 1.5 meters per second, the faster robot committed a foul. If the absolute robot speed difference is less than 0.3 meters per second, both conduct a foul.
+
+===== Robot Stop Speed
+A robot must not move faster than 1.5 meters per second during <<Stop, stop>>. A violation of this rule is only counted once per robot and stoppage.
+
+There is a grace period of 2 seconds for the robots to slow down.
+
+NOTE: This rule does not apply to <<Ball Placement, ball placement>>.
+
+NOTE: Since the stop command is used for manual ball placement and
+<<Robot Substitution, robot substitution>>, the intention of the robot
+speed limit is to avoid robots harming the people on the field.
 
 ===== Ball Placement Interference
 During <<Ball Placement, ball placement>>, all robots of the non-placing team have to keep at least 0.5 meters distance to the line between the ball and the placement position (the forbidden area forms a stadium shape).

--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -56,6 +56,7 @@ The time before lack of progress is called is described in the table: <<lack-of-
 [frame="topbot",options="header"]
 .Lack Of Progress Timings
 [[lack-of-progress-timings]]
+// TODO move a table with all timings to the appendix
 |=============================================================================
 | Situation                                                           | Div A Time | Div B Time
 | <<Kick-Off, kick-off>>                                              | 10 s       | 10 s

--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -197,7 +197,7 @@ NOTE: When the ball is <<Ball In And Out Of Play, out of play>>, the rule <<Robo
 
 
 ===== Crashing
-At the moment of collision of two robots of different teams, the difference of the speed vectors of both robots is taken and projected onto the line that is defined by the position of both robots. If the length of this projection is greater than 1.5 meters per second, the faster robot committed a foul. If the absolute robot speed difference is less than 0.3 meters per second, both conduct a foul but the game will not be stopped.
+At the moment of collision of two robots of different teams, the difference of the speed vectors of both robots is taken and projected onto the line that is defined by the position of both robots. If the length of this projection is greater than 1.5 meters per second, the faster robot committed a foul. If the absolute robot speed difference is less than 0.3 meters per second, both conduct a foul.
 
 
 === Ball Placement Violations

--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -36,6 +36,8 @@ A team member must show appropriate respect to everyone involved in the game. In
 * annoying the <<Referee, referee>> or other persons holding an <<Impartial Roles, impartial role>>
 * not obeying the orders of the <<Referee, referee>>
 
+
+
 === Fouls
 The number of fouls per team is tracked by a counter. Each foul will
 increase the counter by one. Every third increase to the foul counter
@@ -47,6 +49,8 @@ NOTE: Regardless, of the prescribed penalties in this section, if a
 foul is severe or repeated, the referee can choose to immediately
 issue a <<Yellow Card, yellow card>> or in extreme cases a <<Red Card,
 red card>>.
+
+
 
 ==== Stopping Fouls
 Fouls in this section cause the game to <<Stop, stop>> and then resume
@@ -96,6 +100,8 @@ A robot must not <<Dribbling Device, dribble>> the ball further than 1 meter, me
 
 NOTE: Dribblers can still be used to dribble large distances with the ball as long as the robot periodically loses possession, such as kicking the ball ahead of it as human soccer players often do.
 
+
+
 ==== Non Stopping Fouls
 Fouls in this section do not cause a <<Stop, stop>>.
 Instead, the game continues normally.
@@ -114,6 +120,8 @@ A robot must not accelerate the ball faster than 6.5 meters per second in 3D spa
 
 ===== Crashing
 At the moment of collision of two robots of different teams, the difference of the speed vectors of both robots is taken and projected onto the line that is defined by the position of both robots. If the length of this projection is greater than 1.5 meters per second, the faster robot committed a foul. If the absolute robot speed difference is less than 0.3 meters per second, both conduct a foul.
+
+
 
 ==== Fouls While Ball Out Of Play
 Fouls in this section can only occur when the ball is <<Ball In And Out Of Play, out of play>>.

--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -184,8 +184,7 @@ NOTE: Dribblers can still be used to dribble large distances with the ball as lo
 A robot must not accelerate the ball faster than 6.5 meters per second in 3D space.
 
 ===== Defender Too Close To Ball
-A robot's distance to the ball must be at least 0.5 meters during an opponent <<Kick-Off, kick-off>>, <<Free Kick, free kick>>.
-The game is resumed with the same command that was issued before the foul.
+A robot's distance to the ball must be at least 0.5 meters during an opponent <<Kick-Off, kick-off>> or <<Free Kick, free kick>>.
 
 NOTE: During <<Stop, stop>>, there is no automatic sanction for being too close to the ball. The referee may still punish a team for <<Unsporting Behavior,unsporting behavior>> by issuing a <<Yellow Card, yellow card>> if it does not respect the required distance. See <<Stop, stop>> for further explanation.
 

--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -1,24 +1,95 @@
-== Offenses
-Offenses are divided into multiple categories according to the seriousness of the offense: <<Minor Offenses, minor offenses>>, <<Fouls, fouls>> and <<Unsporting Behavior, unsporting behavior>>.
+== Rule Violations
 
-NOTE: Rule of thumb: Minor offenses are infringements of the rules committed by an attacking robot while the ball is <<Ball In And Out Of Play, in play>>. Fouls are infringements of the rules committed by a defender or while the ball is <<Ball In And Out Of Play, out of play>> or infringements that may harm the humans, the robots or the field.
+Rule violations can be broadly divided into two categories:
+<<Offenses>> and <<Fouls>>. The main difference being that fouls
+increase the <<Foul Counter, foul counter>> which can lead to
+additional penalties, such as <<Yellow Card, yellow cards>>.
 
-=== Minor Offenses
-Minor offenses are violations of the rules that result in a stoppage and a subsequent <<Free Kick, free kick>> for the opposing team. The free kick will be shot from the position where the ball was located when the offense began happening (see <<Free Kick, the free kick rules>> for the exact ball position rules).
+There are two broad classesof punishments for rule violations:
 
-All minor offenses are listed below.
+- <<Stop, stop>> followed by a <<Free Kick, free kick>>
+- Increase the <<No Stop Foul, no goal timer>>
+
+Additionally, some violations are handled specially based on the
+referee's discretion including, but not limited to, <<Unsporting
+Behavior, unsporting behavior>> and <<Damaging Other Robots, damaging
+other robots>>.
+
+The remainder of this section is broken down as follow:
+
+- <<Stopping Offenses>>
+- <<Fouls>>
+  - <<Stopping Fouls>>
+  - <<No Stop Fouls>>
+- <<Ball Placement Violations>>
+- <<General Violations>>
+
+NOTE: Regardless, of the prescribed penalties in this section, if a
+foul is severe or repeated, the referee can choose to immediately
+issue a <<Yellow Card, yellow card>> or in extreme cases a <<Red Card,
+red card>>.
+
+=== Simultaneous Offenses
+If the game is <<Stop, stopped>> and a team is allowed to <<Resuming The Game, resume the game>>, <<Minor Offenses, minor offenses>> and <<Fouls, fouls>> of this team's opponent don't affect the method and position of the resumption of the game, except if the resulting method is a <<Penalty Kick, penalty kick>>.
+
+If a team exploits this rule, the referee may punish this team for <<Unsporting Behavior,unsporting behavior>> by issuing a <<Yellow Card, yellow card>>.
+
+NOTE: This rule is in place to prevent teams from purposely committing offenses in order to relocate the opponent <<Free Kick,free kick>> to a more favorable position.
+
+
+=== Stopping Offenses
+
+These Offenses result in a <<Stop, stop>> followed by a <<Free Kick, free kick>>. The rules for ball placement of the
+kick are described in <<Free Kick, the free kick rules>>.
+
 
 ==== Aimless Kick [small]#(_division B only_)#
 A kick is aimless when after the ball touched a robot, it subsequently crossed the midline and then its opponent's goal line outside the goal without touching another robot. A kick-off kick cannot be aimless, as the ball is located at the midline and does therefore not cross it.
 
 ==== Lack Of Progress
-There is a lack of progress if only one team is allowed to <<Ball Manipulation, manipulate the ball>> (<<Kick-Off, kick-off>>, <<Free Kick, free kick>>, <<Penalty Kick, penalty kick>>) and does not bring the ball <<Ball In And Out Of Play, into play>> in time. The time limit is 5 seconds for <<Free Kick, free kicks>> in division A and 10 seconds in all other cases.
 
-There is also a lack of progress if the ball is inside a team's <<Defense Area, defense area>> for 10 seconds, since the keeper is the only robot that is allowed to <<Ball Manipulation, manipulate the ball>>.
+There is a lack of progress if only one team is allowed to <<Ball
+Manipulation, manipulate the ball>> (<<Kick-Off, kick-off>>, <<Direct
+Free Kick, direct free kick>>, <<Indirect Free Kick, indirect free
+kick>>, <<Penalty Kick, penalty kick>>) and does not bring the ball
+<<Ball In And Out Of Play, into play>> in time. The time before lack
+of progress is called is described in the table: <<lack-of-progress-timings>>.
 
-NOTE: If both teams are allowed to manipulate the ball, and thus no team is at fault, the referee may stop the game and issue a <<Force Start, force start>> command.
+[frame="topbot",options="header"]
+.Lack Of Progress Timings
+[[lack-of-progress-timings]]
+|=============================================================================
+| Situation                                                                   | Div A Time | Div B Time
+| <<Kick-Off, kick-off>>                                                     | 10 s       | 10 s
+| <<Penalty Kick, penalty kick>>                                          | 10 s       | 10 s               
+| <<Direct Free Kick, direct free kick>>                                 | 5 s        | 10 s        
+| <<Indirect Free Kick, indirect free kick>>                            | 5 s        | 10 s                  
+| Ball inside <<Defense Area, defense area>>                              | 5 s        | 10 s                  
+| Both teams can manipulate, no progress                                      | 5 s        | 10 s                  
+| Neither team can bring ball <<Ball In And Out Of Play, into play>>  | 5 s        | 10 s                  
+|=============================================================================
 
-NOTE: If both teams are clearly unable to bring the ball <<Ball In And Out Of Play, into play>> without violating the rules, the referee may issue a <<Force Start, force start>> command instead of an <<Free Kick, free kick>> for the other team.
+
+If there is a lack of progress due to the ball being inside a team's
+<<Defense Area, defense area>> past the timeout, then a <<Indirect Free
+Kick, indirect free kick>> is issued for the attacking team.
+
+In the case of <<Kick-Off, kick-off>>, <<Direct Free Kick, direct free
+kick>>, <<Indirect Free Kick, indirect free kick>>, after the time
+expires the ball is considered <<Ball In And Out Of Play, in play>>
+and both teams may manipulate the ball.
+
+In all other cases a <<Stop, stop>> is issued followed by a <<Force Start,
+forced start>>
+This includes situations where both teams can manipulate the ball, but
+the referee determines that no progress is being made.
+
+==== Double Touch
+When the ball is brought <<Ball In And Out Of Play, into play>> following a <<Kick-Off, kick-off>>, <<Direct Free Kick, direct free kick>>, <<Indirect Free Kick, indirect free kick>> or <<Penalty Kick, penalty kick>>, the kicker is not allowed to touch the ball until it has been touched by another robot or the game has been stopped.
+
+The ball must have moved at least 0.05 meters to be considered as <<Ball In And Out Of Play, in play>>.
+
+NOTE: It is understood that the ball may be bumped by the robot multiple times over a short distance while the kick is being taken. This is why a distance of 0.05 meters is used to decide whether a robot violates this rule or not. Remaining in contact with the ball for more than 0.05 meters also counts as double touch, even though technically the robot only touched the ball once.
 
 ==== Double Touch
 When the ball is brought <<Ball In And Out Of Play, into play>> following a <<Kick-Off, kick-off>>, <<Free Kick, free kick>> or <<Penalty Kick, penalty kick>>, the kicker is not allowed to touch the ball until it has been touched by another robot or the game has been stopped.
@@ -27,126 +98,155 @@ The ball must have moved at least 0.05 meters to be considered as <<Ball In And 
 
 NOTE: It is understood that the ball may be bumped by the robot multiple times over a short distance while the kick is being taken. This is why a distance of 0.05 meters is used to decide whether a robot violates this rule or not. Remaining in contact with the ball for more than 0.05 meters also counts as double touch, even though technically the robot only touched the ball once.
 
-==== Attacker In Defense Area
-A robot must not touch the ball while being partially or fully inside the opponent <<Defense Area, defense area>>.
-
-NOTE: When the ball is <<Ball In And Out Of Play, out of play>>, the more strict rule <<Robot Too Close To Opponent Defense Area>> applies instead.
-
-==== Excessive Dribbling
-A robot must not <<Dribbling Device, dribble>> the ball further than 1 meter, measured linearly from the ball location where the dribbling started. A robot begins dribbling when it makes contact with the ball and stops dribbling when there is an observable separation between the ball and the robot.
-
-NOTE: Dribblers can still be used to dribble large distances with the ball as long as the robot periodically loses possession, such as kicking the ball ahead of it as human soccer players often do.
-
-==== Ball Speed
-A robot must not accelerate the ball faster than 6.5 meters per second in 3D space.
 
 === Fouls
-Fouls are violations of the rules that result in a <<Free Kick, free kick>> for the opposing team. The free kick will be shot from the position where the ball was located when the offense began happening (see <<Free Kick, the free kick rules>> for the exact ball position rules). If the foul happened while the ball is <<Ball In And Out Of Play, out of play>>, no free kick is given.
 
-Every third foul of the same team results in a <<Yellow Card, yellow card>>.
+The number of fouls per team is tracked by a counter. Each foul will
+increase the counter by one. Every third increase to the foul counter
+causes a <<Yellow Card, yellow card>> to be awarded.
 
-In case of severe fouls, the referee can also issue a <<Yellow Card, yellow card>> or a <<Red Card, red card>>.
+Every violation in this section and its subsections increase the foul
+counter.
 
-All fouls are listed below.
+Fouls are further subdivided into <<Stopping Fouls>> and <<No Stop
+Fouls>>. Stopping fouls cause a <<Stop, stop>> to be issued and the
+game to resume with a <<Free Kick, free kick>>. No stop
+fouls do not cause a change in the game state, however, time is added
+to a <<No Stop Foul, no goal timer>>.
 
-==== Attacker Touches Robot In Opponent Defense Area
-When the ball <<Ball In And Out Of Play, in play>>, a robot must not touch any opponent robot inside the opponent <<Defense Area, defense area>>.
 
-NOTE: When the ball is <<Ball In And Out Of Play, out of play>>, the rule <<Robot Too Close To Opponent Defense Area>> applies instead.
+==== Stopping Fouls
 
-==== Robot Too Close To Opponent Defense Area
+Fouls in this section cause the game to <<Stop, stop>> and then resume
+with a <<Fre Kick, free kick>>. Like other fouls, this
+also increases the <<Fouls, foul counter>>.
+
+
+===== Robot Too Close To Opponent Defense Area
 During <<Stop, stop>> and <<Free Kick, free kicks>>, before the ball <<Resuming The Game, has entered play>>, all robots have to keep at least 0.2 meters distance to the opponent <<Defense Area, defense area>>.
 
 There is a grace period of 2 seconds for the robots to move away from the opponent defense area.
 
-==== Ball Placement Interference
-During <<Ball Placement, ball placement>>, all robots of the non-placing team have to keep at least 0.5 meters distance to the line between the ball and the placement position (the forbidden area forms a stadium shape).
-
-If a robot of the non-placing team is too close to the line between the ball and the placement position for more than 2 seconds, it commits a foul.
-In this case, the placement procedure is restarted.
-
-NOTE: This rule does not cover all cases of ball placement interference. The <<Referee, referee>> is encouraged to call fouls if the non-placing team is obviously interfering with the ball placement.
-
-==== Crashing
-At the moment of collision of two robots of different teams, the difference of the speed vectors of both robots is taken and projected onto the line that is defined by the position of both robots. If the length of this projection is greater than 1.5 meters per second, the faster robot committed a foul. If the absolute robot speed difference is less than 0.3 meters per second, both conduct a foul but the game will not be stopped.
-
-==== Pushing
+===== Pushing
 A robot pushes an opponent robot if both robots keep contact to the ball or to each other while the robot exerts force onto the opponent robot, such that both robots travel towards the opponent robot.
 
 NOTE: If both robots are pushing each other with similar force, no team is at fault.
 
-==== Ball Holding
+===== Ball Holding
 Robots must not surround the ball to prevent access by others.
 
-==== Tipping Over Or Dropping Parts
+===== Tipping Over Or Dropping Parts
 A robot must not tip over, break or drop parts on the field that pose a potential threat to other robots.
 
 A robot violating this rule has to be <<Robot Substitution, substituted>>.
 
 NOTE: Metal parts (screws for example) as well as larger parts generally pose a potential threat, very small non-metal parts (for example rubber subwheel rings) don't.
 
-==== Robot Stop Speed
+===== Robot Stop Speed
 A robot must not move faster than 1.5 meters per second during <<Stop, stop>>. A violation of this rule is only counted once per robot and stoppage.
 
 There is a grace period of 2 seconds for the robots to slow down.
 
 NOTE: This rule does not apply to <<Ball Placement, ball placement>>.
 
-NOTE: Since the stop command is used for manual ball placement and <<Robot Substitution, robot substitution>>, the intention of the robot speed limit is to avoid robots harming the people on the field.
+NOTE: Since the stop command is used for manual ball placement and
+<<Robot Substitution, robot substitution>>, the intention of the robot
+speed limit is to avoid robots harming the people on the field.
 
-==== Defender Too Close To Ball
-A robot's distance to the ball must be at least 0.5 meters during an opponent <<Kick-Off, kick-off>> or <<Free Kick, free kick>>.
-The game is resumed with the same command that was issued before the foul.
-
-NOTE: During <<Stop, stop>>, there is no automatic sanction for being too close to the ball. The referee may still punish a team for <<Unsporting Behavior,unsporting behavior>> by issuing a <<Yellow Card, yellow card>> if it does not respect the required distance. See <<Stop, stop>> for further explanation.
-
-==== Multiple Defenders
+===== Multiple Defenders
 NOTE: This rule does not use the standard sanctions defined for <<Fouls, fouls>>.
 
 If a robot other than the keeper touches the ball while being partially inside its own defense area, the game is stopped, the robot receives a <<Yellow Card, yellow card>> and the opponent team resumes the game with a <<Free Kick, free kick>>. The foul counter is not increased.
 
-If a robot other than the keeper touches the ball while being entirely inside its own defense area, the game is stopped and a <<Penalty Kick, penalty kick>> is awarded to the other team. The foul counter is not increased.
+If a robot other than the keeper touches the ball while being entirely
+inside its own defense area, the game is stopped and a <<Penalty Kick,
+penalty kick>> is awarded to the other team. The foul counter is not
+increased.
 
-==== Boundary Crossing
+===== Boundary Crossing
 A robot must not kick the ball over the field boundary such that the ball leaves the field.
 
 
-=== Unsporting Behavior
+==== No Stop Fouls
+
+Violations in this section are fouls, but they do not cause a <<Stop,
+stop>>. Instead, the game continues but time is added to a per-team no
+goal timer. Any goal scored by the team while this timer has time
+remaining is <<Scoring Goals, considered invalid>>.
+
+Each violation adds 2 seconds to the timer. The timer is cleared if
+the opposing team scores a <<Scoring Goals, valid goal>> causing a
+<<Kick-Off, kick-off>>. The timer is also cleared at half-time and at
+overtime.
+
+The same no stop foul cannot be triggered again until the foul
+condition has stopped being violated or there has been 1 second since
+the foul was first triggered. This is to allow teams to adjust their
+robots' positions, ball speed or any other property that is causing
+the violation before being penalized additional times.
+
+===== Attacker In Defense Area
+A robot must not touch the ball while being partially or fully inside the opponent <<Defense Area, defense area>>.
+
+NOTE: When the ball is <<Ball In And Out Of Play, out of play>>, the more strict rule <<Robot Too Close To Opponent Defense Area>> applies instead.
+
+===== Excessive Dribbling
+A robot must not <<Dribbling Device, dribble>> the ball further than 1 meter, measured linearly from the ball location where the dribbling started. A robot begins dribbling when it makes contact with the ball and stops dribbling when there is an observable separation between the ball and the robot.
+
+NOTE: Dribblers can still be used to dribble large distances with the ball as long as the robot periodically loses possession, such as kicking the ball ahead of it as human soccer players often do.
+
+===== Ball Speed
+A robot must not accelerate the ball faster than 6.5 meters per second in 3D space.
+
+===== Defender Too Close To Ball
+A robot's distance to the ball must be at least 0.5 meters during an opponent <<Kick-Off, kick-off>>, <<Free Kick, free kick>>.
+The game is resumed with the same command that was issued before the foul.
+
+NOTE: During <<Stop, stop>>, there is no automatic sanction for being too close to the ball. The referee may still punish a team for <<Unsporting Behavior,unsporting behavior>> by issuing a <<Yellow Card, yellow card>> if it does not respect the required distance. See <<Stop, stop>> for further explanation.
+
+===== Attacker Touches Robot In Opponent Defense Area
+When the ball <<Ball In And Out Of Play, in play>>, a robot must not touch any opponent robot inside the opponent <<Defense Area, defense area>>.
+
+NOTE: When the ball is <<Ball In And Out Of Play, out of play>>, the rule <<Robot Too Close To Opponent Defense Area>> applies instead.
+
+
+===== Crashing
+At the moment of collision of two robots of different teams, the difference of the speed vectors of both robots is taken and projected onto the line that is defined by the position of both robots. If the length of this projection is greater than 1.5 meters per second, the faster robot committed a foul. If the absolute robot speed difference is less than 0.3 meters per second, both conduct a foul but the game will not be stopped.
+
+
+=== Ball Placement Violations
+
+==== Ball Placement Interference
+During <<Ball Placement, ball placement>>, all robots of the non-placing team have to keep at least 0.5 meters distance to the line between the ball and the placement position (the forbidden area forms a stadium shape).
+
+
+If a robot of the non-placing team is too close to the line between
+the ball and the placement position for more than 2 seconds, it
+commits a foul. In this case, 10 seconds are added to the ball
+placement timer
+
+NOTE: This rule does not cover all cases of ball placement interference. The <<Referee, referee>> is encouraged to call fouls if the non-placing team is obviously interfering with the ball placement.
+
+
+=== General Violations
+
+
+==== Unsporting Behavior
 Unsporting behavior can lead to <<Yellow Card, yellow cards>>, <<Red Card, red cards>>, <<Penalty Kick, penalty kicks>>, a <<Forced Forfeit, forced forfeit>> or a <<Disqualification, disqualification>>. The human <<Referee, referee>> chooses an appropriate sanction, depending on the severity of the offense.
 
 NOTE: If the referee is not sure which sanction to choose, he may confer with members of the <<Technical Committee, technical committee>> or the <<Organizing Committee, organizing committee>>.
 
 Some examples of unsporting behavior are listed below.
 
-==== Damaging Other Robots
+===== Damaging Other Robots
 It is not allowed to damage or modify robots of other teams.
 
-==== Damaging The Field Or The Ball
+===== Damaging The Field Or The Ball
 It is not allowed to damage or modify the field or the ball.
 
-==== Showing Lack Of Respect
+===== Showing Lack Of Respect
 A team member must show appropriate respect to everyone involved in the game. Infringements of this rule include but are not limited to:
 
 * insulting the opponent, the <<Referee, referee>> or other persons holding an <<Impartial Roles, impartial role>>
 * annoying the <<Referee, referee>> or other persons holding an <<Impartial Roles, impartial role>>
 * not obeying the orders of the <<Referee, referee>>
-
-=== Simultaneous Offenses
-If the game is <<Stop, stopped>> and a team is allowed to <<Resuming The Game, resume the game>>, <<Minor Offenses, minor offenses>> and <<Fouls, fouls>> of this team's opponent don't affect the method and position of the resumption of the game, except if the resulting method is a <<Penalty Kick, penalty kick>>.
-
-If a team exploits this rule, the referee may punish this team for <<Unsporting Behavior,unsporting behavior>> by issuing a <<Yellow Card, yellow card>>.
-
-NOTE: This rule is in place to prevent teams from purposely committing offenses in order to relocate the opponent <<Free Kick, free kick>> to a more favorable position.
-
-=== Advantage Rule
-In certain situations, stopping the game because of a foul may have a disadvantage to the opposing team.
-As these situations are not easy to detect automatically, the opposing team is asked if it likes to continue the game.
-In this case, the game is not stopped and no free kick is awarded at any time.
-The foul counter is still incremented and any resulting cards are given when the game is <<Stop,stopped>>.
-
-.Fouls that are considered
-
-* <<Crashing>>, if not both teams committed the foul
-* <<Attacker Touches Robot In Opponent Defense Area>>
-
-NOTE: If the team is not connected to the game controller or does not reply within 0.2 seconds, the decision of the team defaults to stopping the game.

--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -41,8 +41,7 @@ The number of fouls per team is tracked by a counter. Each foul will
 increase the counter by one. Every third increase to the foul counter
 causes a <<Yellow Card, yellow card>> to be awarded.
 
-Every violation in this section and its subsections increase the foul
-counter.
+Violations in this section and its subsections increase the foul counter if not stated otherwise.
 
 NOTE: Regardless, of the prescribed penalties in this section, if a
 foul is severe or repeated, the referee can choose to immediately

--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -72,8 +72,8 @@ The ball must not be kept in the <<Defense Area, defense area>> for more than
 5 seconds (Division A) or 10 seconds (Division B).
 
 ==== Non Stopping Fouls
-Violations in this section are fouls, but they do not cause a <<Stop,
-stop>>. Instead, the game continues but time is added to a per-team no
+Fouls in this section do not cause a <<Stop, stop>>.
+Instead, the game continues but time is added to a per-team no
 goal timer. Any goal scored by the team while this timer has time
 remaining is <<Scoring Goals, considered invalid>>.
 
@@ -101,9 +101,6 @@ NOTE: Dribblers can still be used to dribble large distances with the ball as lo
 ===== Ball Speed
 A robot must not accelerate the ball faster than 6.5 meters per second in 3D space.
 
-===== Defender Too Close To Ball
-A robot's distance to the ball must be at least 0.5 meters during an opponent <<Kick-Off, kick-off>> or <<Free Kick, free kick>>.
-
 The <<Referee, human referee>> may decide to repeat the <<Kick-Off, kick-off>> or <<Free Kick, free kick>> on significant disturbances.
 
 NOTE: During <<Stop, stop>>, there is no automatic sanction for being too close to the ball. The referee may still punish a team for <<Unsporting Behavior,unsporting behavior>> by issuing a <<Yellow Card, yellow card>> if it does not respect the required distance. See <<Stop, stop>> for further explanation.
@@ -115,6 +112,19 @@ NOTE: When the ball is <<Ball In And Out Of Play, out of play>>, the rule <<Robo
 
 ===== Crashing
 At the moment of collision of two robots of different teams, the difference of the speed vectors of both robots is taken and projected onto the line that is defined by the position of both robots. If the length of this projection is greater than 1.5 meters per second, the faster robot committed a foul. If the absolute robot speed difference is less than 0.3 meters per second, both conduct a foul.
+
+==== Fouls During Stop
+Fouls in this section can only occur when the ball is <<Ball In And Out Of Play, out of play>>.
+
+Each foul has a grace period of 2 seconds per team until it is raised again.
+
+NOTE: If multiple robots commit the same foul within 2 seconds, only the first foul counts.
+
+NOTE: If a robot keeps committing a foul, it will be punished again after the grace period.
+
+===== Defender Too Close To Ball
+A robot's distance to the ball must be at least 0.5 meters during an opponent <<Kick-Off, kick-off>> or <<Free Kick, free kick>>.
+While the foul is being committed, the timer of the opponent team for bringing the ball into play is reset.
 
 ===== Robot Stop Speed
 A robot must not move faster than 1.5 meters per second during <<Stop, stop>>. A violation of this rule is only counted once per robot and stoppage.

--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -101,18 +101,11 @@ causes a <<Yellow Card, yellow card>> to be awarded.
 Every violation in this section and its subsections increase the foul
 counter.
 
-Fouls are further subdivided into <<Stopping Fouls>> and <<No Stop
-Fouls>>. Stopping fouls cause a <<Stop, stop>> to be issued and the
-game to resume with a <<Free Kick, free kick>>. No stop
-fouls do not cause a change in the game state, however, time is added
-to a <<No Stop Foul, no goal timer>>.
-
 
 ==== Stopping Fouls
 
 Fouls in this section cause the game to <<Stop, stop>> and then resume
-with a <<Fre Kick, free kick>>. Like other fouls, this
-also increases the <<Fouls, foul counter>>.
+with a <<Free Kick, free kick>>.
 
 
 ===== Robot Too Close To Opponent Defense Area
@@ -168,9 +161,8 @@ goal timer. Any goal scored by the team while this timer has time
 remaining is <<Scoring Goals, considered invalid>>.
 
 Each violation adds 2 seconds to the timer. The timer is cleared if
-the opposing team scores a <<Scoring Goals, valid goal>> causing a
-<<Kick-Off, kick-off>>. The timer is also cleared at half-time and at
-overtime.
+the opposing team scores a <<Scoring Goals, valid goal>>.
+The timer is also cleared at half-time and at overtime.
 
 The same no stop foul cannot be triggered again until the foul
 condition has stopped being violated or there has been 1 second since

--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -76,11 +76,12 @@ NOTE: Metal parts (screws for example) as well as larger parts generally pose a 
 ===== Multiple Defenders
 NOTE: This rule does not use the standard sanctions defined for <<Fouls, fouls>>.
 
-If a robot other than the keeper touches the ball while being partially inside its own defense area, the game is stopped, the robot receives a <<Yellow Card, yellow card>> and the opponent team resumes the game with a <<Free Kick, free kick>>. The foul counter is not increased.
+Robots other than the keeper must maintain best-effort to fully stay outside the own defense area.
+Infraction of this rule can be rated as unsporting behavior.
 
 If a robot other than the keeper touches the ball while being entirely
 inside its own defense area, the game is stopped and a <<Penalty Kick,
-penalty kick>> is awarded to the other team. The foul counter is not
+penalty kick>> is awarded to the other team. The foul counter is *not*
 increased.
 
 ===== Boundary Crossing
@@ -90,40 +91,26 @@ A robot must not kick the ball over the field boundary such that the ball leaves
 The ball must not be kept in the <<Defense Area, defense area>> for more than
 5 seconds (Division A) or 10 seconds (Division B).
 
-==== Non Stopping Fouls
-Fouls in this section do not cause a <<Stop, stop>>.
-Instead, the game continues but time is added to a per-team no
-goal timer. Any goal scored by the team while this timer has time
-remaining is <<Scoring Goals, considered invalid>>.
-
-Each violation adds 2 seconds to the timer. The timer is cleared
-
-* if the opposing team scores a <<Scoring Goals, valid goal>>.
-* at half-time and at overtime.
-
-The same no stop foul cannot be triggered again until the foul
-condition has stopped being violated or there has been 1 second since
-the foul was first triggered. This is to allow teams to adjust their
-robots' positions, ball speed or any other property that is causing
-the violation before being penalized additional times.
-
-===== Attacker In Defense Area
-A robot must not touch the ball while being partially or fully inside the opponent <<Defense Area, defense area>>.
-
-NOTE: When the ball is <<Ball In And Out Of Play, out of play>>, the more strict rule <<Robot Too Close To Opponent Defense Area>> applies instead.
-
 ===== Excessive Dribbling
 A robot must not <<Dribbling Device, dribble>> the ball further than 1 meter, measured linearly from the ball location where the dribbling started. A robot begins dribbling when it makes contact with the ball and stops dribbling when there is an observable separation between the ball and the robot.
 
 NOTE: Dribblers can still be used to dribble large distances with the ball as long as the robot periodically loses possession, such as kicking the ball ahead of it as human soccer players often do.
 
+==== Non Stopping Fouls
+Fouls in this section do not cause a <<Stop, stop>>.
+Instead, the game continues normally.
+
+The same no stop foul cannot be triggered again until the foul
+condition has stopped being violated or there has been 2 seconds since
+the foul was first triggered. This is to allow teams to adjust their
+robots' positions, ball speed or any other property that is causing
+the violation before being penalized additional times.
+
+===== Attacker Touched Ball In Opponent Defense Area
+The ball must not be touched while being partially or fully inside the opponent <<Defense Area, defense area>>.
+
 ===== Ball Speed
 A robot must not accelerate the ball faster than 6.5 meters per second in 3D space.
-
-===== Attacker Touches Robot In Opponent Defense Area
-When the ball is <<Ball In And Out Of Play, in play>>, a robot must not touch any opponent robot inside the opponent <<Defense Area, defense area>>.
-
-NOTE: When the ball is <<Ball In And Out Of Play, out of play>>, the rule <<Robot Too Close To Opponent Defense Area>> applies instead.
 
 ===== Crashing
 At the moment of collision of two robots of different teams, the difference of the speed vectors of both robots is taken and projected onto the line that is defined by the position of both robots. If the length of this projection is greater than 1.5 meters per second, the faster robot committed a foul. If the absolute robot speed difference is less than 0.3 meters per second, both conduct a foul.

--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -71,7 +71,7 @@ A robot must not kick the ball over the field boundary such that the ball leaves
 The ball must not be kept in the <<Defense Area, defense area>> for more than
 5 seconds (Division A) or 10 seconds (Division B).
 
-==== No Stop Fouls
+==== Non Stopping Fouls
 Violations in this section are fouls, but they do not cause a <<Stop,
 stop>>. Instead, the game continues but time is added to a per-team no
 goal timer. Any goal scored by the team while this timer has time

--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -43,9 +43,6 @@ These Offenses result in a <<Stop, stop>> followed by a <<Free Kick, free kick>>
 kick are described in <<Free Kick, the free kick rules>>.
 
 
-==== Aimless Kick [small]#(_division B only_)#
-A kick is aimless when after the ball touched a robot, it subsequently crossed the midline and then its opponent's goal line outside the goal without touching another robot. A kick-off kick cannot be aimless, as the ball is located at the midline and does therefore not cross it.
-
 ==== No Progress In Game
 If there is no progress in the game while both teams are allowed to
 <<Ball Manipulation, manipulate the ball>>, the game is <<Stop, stopped>>

--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -1,63 +1,22 @@
 == Rule Violations
-
-Rule violations can be broadly divided into two categories:
-<<Offenses>> and <<Fouls>>. The main difference being that fouls
-increase the <<Foul Counter, foul counter>> which can lead to
-additional penalties, such as <<Yellow Card, yellow cards>>.
-
-There are two broad classesof punishments for rule violations:
-
-- <<Stop, stop>> followed by a <<Free Kick, free kick>>
-- Increase the <<No Stop Foul, no goal timer>>
-
-Additionally, some violations are handled specially based on the
-referee's discretion including, but not limited to, <<Unsporting
-Behavior, unsporting behavior>> and <<Damaging Other Robots, damaging
-other robots>>.
-
-The remainder of this section is broken down as follow:
-
-- <<Stopping Offenses>>
-- <<Fouls>>
-  - <<Stopping Fouls>>
-  - <<No Stop Fouls>>
-- <<Ball Placement Violations>>
-- <<General Violations>>
-
-NOTE: Regardless, of the prescribed penalties in this section, if a
-foul is severe or repeated, the referee can choose to immediately
-issue a <<Yellow Card, yellow card>> or in extreme cases a <<Red Card,
-red card>>.
-
-=== Simultaneous Offenses
-If the game is <<Stop, stopped>> and a team is allowed to <<Resuming The Game, resume the game>>, <<Minor Offenses, minor offenses>> and <<Fouls, fouls>> of this team's opponent don't affect the method and position of the resumption of the game, except if the resulting method is a <<Penalty Kick, penalty kick>>.
-
-If a team exploits this rule, the referee may punish this team for <<Unsporting Behavior,unsporting behavior>> by issuing a <<Yellow Card, yellow card>>.
-
-NOTE: This rule is in place to prevent teams from purposely committing offenses in order to relocate the opponent <<Free Kick,free kick>> to a more favorable position.
-
-
-=== Stopping Offenses
-
-These Offenses result in a <<Stop, stop>> followed by a <<Free Kick, free kick>>. The rules for ball placement of the
-kick are described in <<Free Kick, the free kick rules>>.
-
-
-==== No Progress In Game
+=== No Progress In Game
 If there is no progress in the game while both teams are allowed to
 <<Ball Manipulation, manipulate the ball>>, the game is <<Stop, stopped>>
 and continued by a <<Force Start, forced start>>.
 
-==== Double Touch
-When the ball is brought <<Ball In And Out Of Play, into play>> following a <<Kick-Off, kick-off>> or <<Free Kick, free kick>>, the kicker is not allowed to touch the ball until it has been touched by another robot or the game has been stopped.
+=== Double Touch
+When the ball is brought <<Ball In And Out Of Play, into play>> following a <<Kick-Off, kick-off>> or <<Free Kick, free kick>>,
+the kicker is not allowed to touch the ball until it has been touched by another robot or the game has been stopped.
 
 The ball must have moved at least 0.05 meters to be considered as <<Ball In And Out Of Play, in play>>.
 
-NOTE: It is understood that the ball may be bumped by the robot multiple times over a short distance while the kick is being taken. This is why a distance of 0.05 meters is used to decide whether a robot violates this rule or not. Remaining in contact with the ball for more than 0.05 meters also counts as double touch, even though technically the robot only touched the ball once.
+A double touch results in a <<Stop, stop>> followed by a <<Free Kick, free kick>> from the same ball position.
 
+NOTE: It is understood that the ball may be bumped by the robot multiple times over a short distance while the kick is being taken.
+This is why a distance of 0.05 meters is used to decide whether a robot violates this rule or not.
+Remaining in contact with the ball for more than 0.05 meters also counts as double touch, even though technically the robot only touched the ball once.
 
 === Fouls
-
 The number of fouls per team is tracked by a counter. Each foul will
 increase the counter by one. Every third increase to the foul counter
 causes a <<Yellow Card, yellow card>> to be awarded.
@@ -65,12 +24,15 @@ causes a <<Yellow Card, yellow card>> to be awarded.
 Every violation in this section and its subsections increase the foul
 counter.
 
+NOTE: Regardless, of the prescribed penalties in this section, if a
+foul is severe or repeated, the referee can choose to immediately
+issue a <<Yellow Card, yellow card>> or in extreme cases a <<Red Card,
+red card>>.
 
 ==== Stopping Fouls
-
 Fouls in this section cause the game to <<Stop, stop>> and then resume
-with a <<Free Kick, free kick>>.
-
+with a <<Free Kick, free kick>> from the position where the ball was
+located when the foul began happening.
 
 ===== Robot Too Close To Opponent Defense Area
 During <<Stop, stop>> and <<Free Kick, free kicks>>, before the ball <<Resuming The Game, has entered play>>, all robots have to keep at least 0.2 meters distance to the opponent <<Defense Area, defense area>>.
@@ -121,15 +83,15 @@ The ball must not be kept in the <<Defense Area, defense area>> for more than
 5 seconds (Division A) or 10 seconds (Division B).
 
 ==== No Stop Fouls
-
 Violations in this section are fouls, but they do not cause a <<Stop,
 stop>>. Instead, the game continues but time is added to a per-team no
 goal timer. Any goal scored by the team while this timer has time
 remaining is <<Scoring Goals, considered invalid>>.
 
-Each violation adds 2 seconds to the timer. The timer is cleared if
-the opposing team scores a <<Scoring Goals, valid goal>>.
-The timer is also cleared at half-time and at overtime.
+Each violation adds 2 seconds to the timer. The timer is cleared
+
+* if the opposing team scores a <<Scoring Goals, valid goal>>.
+* at half-time and at overtime.
 
 The same no stop foul cannot be triggered again until the foul
 condition has stopped being violated or there has been 1 second since
@@ -162,42 +124,34 @@ When the ball <<Ball In And Out Of Play, in play>>, a robot must not touch any o
 
 NOTE: When the ball is <<Ball In And Out Of Play, out of play>>, the rule <<Robot Too Close To Opponent Defense Area>> applies instead.
 
-
 ===== Crashing
 At the moment of collision of two robots of different teams, the difference of the speed vectors of both robots is taken and projected onto the line that is defined by the position of both robots. If the length of this projection is greater than 1.5 meters per second, the faster robot committed a foul. If the absolute robot speed difference is less than 0.3 meters per second, both conduct a foul.
 
-
-=== Ball Placement Violations
-
-==== Ball Placement Interference
+===== Ball Placement Interference
 During <<Ball Placement, ball placement>>, all robots of the non-placing team have to keep at least 0.5 meters distance to the line between the ball and the placement position (the forbidden area forms a stadium shape).
-
 
 If a robot of the non-placing team is too close to the line between
 the ball and the placement position for more than 2 seconds, it
 commits a foul. In this case, 10 seconds are added to the ball
-placement timer
+placement timer.
 
-NOTE: This rule does not cover all cases of ball placement interference. The <<Referee, referee>> is encouraged to call fouls if the non-placing team is obviously interfering with the ball placement.
+NOTE: This rule does not cover all cases of ball placement interference.
+The <<Referee, referee>> is encouraged to call fouls if the non-placing team is obviously interfering with the ball placement.
 
-
-=== General Violations
-
-
-==== Unsporting Behavior
+=== Unsporting Behavior
 Unsporting behavior can lead to <<Yellow Card, yellow cards>>, <<Red Card, red cards>>, <<Penalty Kick, penalty kicks>>, a <<Forced Forfeit, forced forfeit>> or a <<Disqualification, disqualification>>. The human <<Referee, referee>> chooses an appropriate sanction, depending on the severity of the offense.
 
 NOTE: If the referee is not sure which sanction to choose, he may confer with members of the <<Technical Committee, technical committee>> or the <<Organizing Committee, organizing committee>>.
 
 Some examples of unsporting behavior are listed below.
 
-===== Damaging Other Robots
+==== Damaging Other Robots
 It is not allowed to damage or modify robots of other teams.
 
-===== Damaging The Field Or The Ball
+==== Damaging The Field Or The Ball
 It is not allowed to damage or modify the field or the ball.
 
-===== Showing Lack Of Respect
+==== Showing Lack Of Respect
 A team member must show appropriate respect to everyone involved in the game. Infringements of this rule include but are not limited to:
 
 * insulting the opponent, the <<Referee, referee>> or other persons holding an <<Impartial Roles, impartial role>>

--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -1,6 +1,6 @@
 == Offenses
 === No Progress In Game
-If there is no progress in the game while both teams are allowed to
+If there is no progress in the game for 5 seconds (Division A) or 10 seconds (Division B) while both teams are allowed to
 <<Ball Manipulation, manipulate the ball>>, the game is <<Stop, stopped>>
 and continued by a <<Force Start, forced start>>.
 

--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -46,40 +46,10 @@ kick are described in <<Free Kick, the free kick rules>>.
 ==== Aimless Kick [small]#(_division B only_)#
 A kick is aimless when after the ball touched a robot, it subsequently crossed the midline and then its opponent's goal line outside the goal without touching another robot. A kick-off kick cannot be aimless, as the ball is located at the midline and does therefore not cross it.
 
-==== Lack Of Progress
-
-There is a lack of progress if only one team is allowed to <<Ball
-Manipulation, manipulate the ball>> (<<Kick-Off, kick-off>>, <<Free Kick, free kick>>)
-and does not bring the ball <<Ball In And Out Of Play, into play>> in time.
-The time before lack of progress is called is described in the table: <<lack-of-progress-timings>>.
-
-[frame="topbot",options="header"]
-.Lack Of Progress Timings
-[[lack-of-progress-timings]]
-// TODO move a table with all timings to the appendix
-|=============================================================================
-| Situation                                                           | Div A Time | Div B Time
-| <<Kick-Off, kick-off>>                                              | 10 s       | 10 s
-| <<Free Kick, free kick>>                                            |  5 s       | 10 s
-| Ball inside <<Defense Area, defense area>>                          |  5 s       | 10 s
-| Both teams can manipulate, no progress                              |  5 s       | 10 s
-| Neither team can bring ball <<Ball In And Out Of Play, into play>>  |  5 s       | 10 s
-|=============================================================================
-
-
-If there is a lack of progress due to the ball being inside a team's
-<<Defense Area, defense area>> past the timeout, then a <<Free
-Kick, free kick>> is issued for the attacking team.
-
-In the case of <<Kick-Off, kick-off>> and <<Free Kick, free kick>>, after the time
-expires the ball is considered <<Ball In And Out Of Play, in play>>
-and both teams may manipulate the ball.
-
-In all other cases a <<Stop, stop>> is issued followed by a <<Force Start,
-forced start>>
-This includes situations where both teams can manipulate the ball, but
-the referee determines that no progress is being made.
-
+==== No Progress In Game
+If there is no progress in the game while both teams are allowed to
+<<Ball Manipulation, manipulate the ball>>, the game is <<Stop, stopped>>
+and continued by a <<Force Start, forced start>>.
 
 ==== Double Touch
 When the ball is brought <<Ball In And Out Of Play, into play>> following a <<Kick-Off, kick-off>> or <<Free Kick, free kick>>, the kicker is not allowed to touch the ball until it has been touched by another robot or the game has been stopped.
@@ -149,6 +119,9 @@ increased.
 ===== Boundary Crossing
 A robot must not kick the ball over the field boundary such that the ball leaves the field.
 
+===== Keeper Held Ball
+The ball must not be kept in the <<Defense Area, defense area>> for more than
+5 seconds (Division A) or 10 seconds (Division B).
 
 ==== No Stop Fouls
 

--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -59,14 +59,13 @@ of progress is called is described in the table: <<lack-of-progress-timings>>.
 .Lack Of Progress Timings
 [[lack-of-progress-timings]]
 |=============================================================================
-| Situation                                                                   | Div A Time | Div B Time
-| <<Kick-Off, kick-off>>                                                     | 10 s       | 10 s
-| <<Penalty Kick, penalty kick>>                                          | 10 s       | 10 s               
-| <<Direct Free Kick, direct free kick>>                                 | 5 s        | 10 s        
-| <<Indirect Free Kick, indirect free kick>>                            | 5 s        | 10 s                  
-| Ball inside <<Defense Area, defense area>>                              | 5 s        | 10 s                  
-| Both teams can manipulate, no progress                                      | 5 s        | 10 s                  
-| Neither team can bring ball <<Ball In And Out Of Play, into play>>  | 5 s        | 10 s                  
+| Situation                                                           | Div A Time | Div B Time
+| <<Kick-Off, kick-off>>                                              | 10 s       | 10 s
+| <<Penalty Kick, penalty kick>>                                      | 10 s       | 10 s
+| <<Free Kick, free kick>>                                     |  5 s       | 10 s
+| Ball inside <<Defense Area, defense area>>                          |  5 s       | 10 s
+| Both teams can manipulate, no progress                              |  5 s       | 10 s
+| Neither team can bring ball <<Ball In And Out Of Play, into play>>  |  5 s       | 10 s
 |=============================================================================
 
 
@@ -84,12 +83,6 @@ forced start>>
 This includes situations where both teams can manipulate the ball, but
 the referee determines that no progress is being made.
 
-==== Double Touch
-When the ball is brought <<Ball In And Out Of Play, into play>> following a <<Kick-Off, kick-off>>, <<Direct Free Kick, direct free kick>>, <<Indirect Free Kick, indirect free kick>> or <<Penalty Kick, penalty kick>>, the kicker is not allowed to touch the ball until it has been touched by another robot or the game has been stopped.
-
-The ball must have moved at least 0.05 meters to be considered as <<Ball In And Out Of Play, in play>>.
-
-NOTE: It is understood that the ball may be bumped by the robot multiple times over a short distance while the kick is being taken. This is why a distance of 0.05 meters is used to decide whether a robot violates this rule or not. Remaining in contact with the ball for more than 0.05 meters also counts as double touch, even though technically the robot only touched the ball once.
 
 ==== Double Touch
 When the ball is brought <<Ball In And Out Of Play, into play>> following a <<Kick-Off, kick-off>>, <<Free Kick, free kick>> or <<Penalty Kick, penalty kick>>, the kicker is not allowed to touch the ball until it has been touched by another robot or the game has been stopped.

--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -16,6 +16,26 @@ NOTE: It is understood that the ball may be bumped by the robot multiple times o
 This is why a distance of 0.05 meters is used to decide whether a robot violates this rule or not.
 Remaining in contact with the ball for more than 0.05 meters also counts as double touch, even though technically the robot only touched the ball once.
 
+=== Unsporting Behavior
+Unsporting behavior can lead to <<Yellow Card, yellow cards>>, <<Red Card, red cards>>, <<Penalty Kick, penalty kicks>>, a <<Forced Forfeit, forced forfeit>> or a <<Disqualification, disqualification>>. The human <<Referee, referee>> chooses an appropriate sanction, depending on the severity of the offense.
+
+NOTE: If the referee is not sure which sanction to choose, he may confer with members of the <<Technical Committee, technical committee>> or the <<Organizing Committee, organizing committee>>.
+
+Some examples of unsporting behavior are listed below.
+
+==== Damaging Other Robots
+It is not allowed to damage or modify robots of other teams.
+
+==== Damaging The Field Or The Ball
+It is not allowed to damage or modify the field or the ball.
+
+==== Showing Lack Of Respect
+A team member must show appropriate respect to everyone involved in the game. Infringements of this rule include but are not limited to:
+
+* insulting the opponent, the <<Referee, referee>> or other persons holding an <<Impartial Roles, impartial role>>
+* annoying the <<Referee, referee>> or other persons holding an <<Impartial Roles, impartial role>>
+* not obeying the orders of the <<Referee, referee>>
+
 === Fouls
 The number of fouls per team is tracked by a counter. Each foul will
 increase the counter by one. Every third increase to the foul counter
@@ -147,23 +167,3 @@ placement timer.
 
 NOTE: This rule does not cover all cases of ball placement interference.
 The <<Referee, referee>> is encouraged to call fouls if the non-placing team is obviously interfering with the ball placement.
-
-=== Unsporting Behavior
-Unsporting behavior can lead to <<Yellow Card, yellow cards>>, <<Red Card, red cards>>, <<Penalty Kick, penalty kicks>>, a <<Forced Forfeit, forced forfeit>> or a <<Disqualification, disqualification>>. The human <<Referee, referee>> chooses an appropriate sanction, depending on the severity of the offense.
-
-NOTE: If the referee is not sure which sanction to choose, he may confer with members of the <<Technical Committee, technical committee>> or the <<Organizing Committee, organizing committee>>.
-
-Some examples of unsporting behavior are listed below.
-
-==== Damaging Other Robots
-It is not allowed to damage or modify robots of other teams.
-
-==== Damaging The Field Or The Ball
-It is not allowed to damage or modify the field or the ball.
-
-==== Showing Lack Of Respect
-A team member must show appropriate respect to everyone involved in the game. Infringements of this rule include but are not limited to:
-
-* insulting the opponent, the <<Referee, referee>> or other persons holding an <<Impartial Roles, impartial role>>
-* annoying the <<Referee, referee>> or other persons holding an <<Impartial Roles, impartial role>>
-* not obeying the orders of the <<Referee, referee>>

--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -51,7 +51,7 @@ A kick is aimless when after the ball touched a robot, it subsequently crossed t
 There is a lack of progress if only one team is allowed to <<Ball
 Manipulation, manipulate the ball>> (<<Kick-Off, kick-off>>, <<Direct
 Free Kick, direct free kick>>, <<Indirect Free Kick, indirect free
-kick>>, <<Penalty Kick, penalty kick>>) and does not bring the ball
+kick>>) and does not bring the ball
 <<Ball In And Out Of Play, into play>> in time. The time before lack
 of progress is called is described in the table: <<lack-of-progress-timings>>.
 
@@ -61,7 +61,6 @@ of progress is called is described in the table: <<lack-of-progress-timings>>.
 |=============================================================================
 | Situation                                                           | Div A Time | Div B Time
 | <<Kick-Off, kick-off>>                                              | 10 s       | 10 s
-| <<Penalty Kick, penalty kick>>                                      | 10 s       | 10 s
 | <<Free Kick, free kick>>                                            |  5 s       | 10 s
 | Ball inside <<Defense Area, defense area>>                          |  5 s       | 10 s
 | Both teams can manipulate, no progress                              |  5 s       | 10 s
@@ -85,7 +84,7 @@ the referee determines that no progress is being made.
 
 
 ==== Double Touch
-When the ball is brought <<Ball In And Out Of Play, into play>> following a <<Kick-Off, kick-off>>, <<Free Kick, free kick>> or <<Penalty Kick, penalty kick>>, the kicker is not allowed to touch the ball until it has been touched by another robot or the game has been stopped.
+When the ball is brought <<Ball In And Out Of Play, into play>> following a <<Kick-Off, kick-off>> or <<Free Kick, free kick>>, the kicker is not allowed to touch the ball until it has been touched by another robot or the game has been stopped.
 
 The ball must have moved at least 0.05 meters to be considered as <<Ball In And Out Of Play, in play>>.
 

--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -62,7 +62,7 @@ of progress is called is described in the table: <<lack-of-progress-timings>>.
 | Situation                                                           | Div A Time | Div B Time
 | <<Kick-Off, kick-off>>                                              | 10 s       | 10 s
 | <<Penalty Kick, penalty kick>>                                      | 10 s       | 10 s
-| <<Free Kick, free kick>>                                     |  5 s       | 10 s
+| <<Free Kick, free kick>>                                            |  5 s       | 10 s
 | Ball inside <<Defense Area, defense area>>                          |  5 s       | 10 s
 | Both teams can manipulate, no progress                              |  5 s       | 10 s
 | Neither team can bring ball <<Ball In And Out Of Play, into play>>  |  5 s       | 10 s
@@ -70,8 +70,8 @@ of progress is called is described in the table: <<lack-of-progress-timings>>.
 
 
 If there is a lack of progress due to the ball being inside a team's
-<<Defense Area, defense area>> past the timeout, then a <<Indirect Free
-Kick, indirect free kick>> is issued for the attacking team.
+<<Defense Area, defense area>> past the timeout, then a <<Free
+Kick, free kick>> is issued for the attacking team.
 
 In the case of <<Kick-Off, kick-off>>, <<Direct Free Kick, direct free
 kick>>, <<Indirect Free Kick, indirect free kick>>, after the time

--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -126,7 +126,7 @@ The <<Referee, human referee>> may decide to repeat the <<Kick-Off, kick-off>> o
 NOTE: During <<Stop, stop>>, there is no automatic sanction for being too close to the ball. The referee may still punish a team for <<Unsporting Behavior,unsporting behavior>> by issuing a <<Yellow Card, yellow card>> if it does not respect the required distance. See <<Stop, stop>> for further explanation.
 
 ===== Attacker Touches Robot In Opponent Defense Area
-When the ball <<Ball In And Out Of Play, in play>>, a robot must not touch any opponent robot inside the opponent <<Defense Area, defense area>>.
+When the ball is <<Ball In And Out Of Play, in play>>, a robot must not touch any opponent robot inside the opponent <<Defense Area, defense area>>.
 
 NOTE: When the ball is <<Ball In And Out Of Play, out of play>>, the rule <<Robot Too Close To Opponent Defense Area>> applies instead.
 

--- a/chapters/playingenvironment.adoc
+++ b/chapters/playingenvironment.adoc
@@ -81,7 +81,7 @@ Besides the shared vision equipment, teams are not allowed to mount their own ca
 A game is controlled by the community-maintained ssl-game-controller (https://github.com/RoboCup-SSL/ssl-game-controller).
 It is operated by the <<Game Controller Operator, game controller operator>>. The software translates decisions of the <<Referee, referee>> and the <<Automatic Referee, automatic referee>> into Ethernet communication signals that are broadcast to the network. It maintains the state of the game, tracks all events and acts as a proxy between all participating parties in the game.
 
-The game-controller has a network interface for the playing teams. They can automatically <<Choosing Keeper Id, change their keeper id>>, they can signal a robot substitution intent for the next opportunity and they can reply to requests of the <<Advantage Rule, advantage rule>>.
+The game-controller has a network interface for the playing teams. They can automatically <<Choosing Keeper Id, change their keeper id>>, they can signal a robot substitution intent for the next opportunity.
 
 ==== Automatic Referee
 One or more automatic referee applications can supervise a game and report <<Offenses, offenses>> to the <<Game Controller, game controller>>.

--- a/chapters/playingenvironment.adoc
+++ b/chapters/playingenvironment.adoc
@@ -96,10 +96,10 @@ Existing implementations can be found on Github: https://github.com/RoboCup-SSL/
 === Communication Flags
 
 The communication flags are used to avoid gesturing and yelling with the <<Referee, referee>> during a match.
-These flags are responsible for communicating various intents, such as: <<Timeouts, timeouts>>, <<Emergency stop, emergency stops>>, <<Robot Substitution, manual robot substitution>> and <<Challenge flags, challenges>>.
+These flags are responsible for communicating various intents, such as: <<Timeouts, timeouts>>, <<Emergency stop, emergency stops>>, <<Robot Substitution, manual robot substitution>> and <<Challenge Flags, challenges>>.
 
 The <<Referee, referee>> or <<Game Controller Operator, game controller operator>> has to acknowledge the communication flag.
-Any gesturing and yelling will be considered <<Unsporting Behavior, unsporting behavior>>, punished by a <<Red card, red card>> after the first warning.
+Any gesturing and yelling will be considered <<Unsporting Behavior, unsporting behavior>>, punished by a <<Red Card, red card>> after the first warning.
 
 The communication flags are provided by the organizers of the competition.
 A remote control software or device can be provided and replace physical flags.

--- a/chapters/playingenvironment.adoc
+++ b/chapters/playingenvironment.adoc
@@ -81,7 +81,7 @@ Besides the shared vision equipment, teams are not allowed to mount their own ca
 A game is controlled by the community-maintained ssl-game-controller (https://github.com/RoboCup-SSL/ssl-game-controller).
 It is operated by the <<Game Controller Operator, game controller operator>>. The software translates decisions of the <<Referee, referee>> and the <<Automatic Referee, automatic referee>> into Ethernet communication signals that are broadcast to the network. It maintains the state of the game, tracks all events and acts as a proxy between all participating parties in the game.
 
-The game-controller has a network interface for the playing teams. They can automatically <<Choosing Keeper Id, change their keeper id>>, they can signal a robot substitution intent for the next opportunity.
+The game-controller has a network interface for the playing teams. They can automatically <<Choosing Keeper Id, change their keeper id>> and they can signal a robot substitution intent for the next opportunity.
 
 ==== Automatic Referee
 One or more automatic referee applications can supervise a game and report <<Offenses, offenses>> to the <<Game Controller, game controller>>.

--- a/chapters/playingenvironment.adoc
+++ b/chapters/playingenvironment.adoc
@@ -90,6 +90,7 @@ At least one automatic referee is required per game. If more than one automatic 
 New automatic referee implementations can be provided, given that the source code is open-sourced. New implementations must be announced at least three months before the competition. The <<Technical Committee, technical committee>> decides if an implementation will be used or not.
 
 The <<Game Event Table>> shows which game events an automatic referee implementation must be able to detect.
+Individual game events can be disabled completely or in some automatic referee implementations if both teams and the <<Technical Committee, technical committee>> agree.
 
 Existing implementations can be found on Github: https://github.com/RoboCup-SSL/ssl-autorefs.
 

--- a/chapters/refereecommands.adoc
+++ b/chapters/refereecommands.adoc
@@ -131,14 +131,15 @@ The procedure of a penalty kick is as follows:
 . The ball is placed by the human referee on the <<Penalty Mark, penalty mark>>.
 . When the <<Penalty Kick, penalty>> command is issued
 .. The defending keeper has to move to the goal line and keep touching it
-.. One attacking robot is allowed to approach the ball but not touch the ball
+.. One attacking robot is allowed to approach the ball but not allowed to touch the ball
 .. All other robots have to be 1m behind the ball such that they do not interfere the penalty kick procedure at any time.
 . When the <<Normal Start, normal start>> command is issued, the attacker is allowed to <<Ball Manipulation, manipulate the ball>>. The ball has to only move towards the opponent goal, as measured by its x coordinate in the coordinate system of <<Vision, SSL-Vision>>.
 . When the ball is <<Ball In And Out Of Play, in play>>, the defending keeper may move freely again
+. If the ball is still <<Ball In And Out Of Play, in play>> after 10 seconds, the game is stopped and then continued by a <<Goal Kick, goal kick>> for the defending team.
 
 A goal is awarded if:
 
-* the ball touches the inner surface of a goal wall or the ground of the goal of the defending team in less than 10 seconds, starting from when the <<Normal Start, normal start>> command is issued
+* the ball touches the inner surface of a goal wall or the ground of the goal of the defending team, starting from when the <<Normal Start, normal start>> command is issued
 * the defending team violates any rule
 
 A goal is not awarded if:
@@ -149,8 +150,6 @@ A goal is not awarded if:
 
 NOTE: The restrictions defined for <<Scoring Goals, scoring goals>>, including the ball height limit of 0.15 meters, do not apply here.
 Other rules like the <<Excessive Dribbling, excessive dribbling>> limitation for example do.
-
-When the ball is <<Ball In And Out Of Play, in play>>, the kicker may not touch the ball until it has been touched by another robot or the game has been stopped (see <<Double Touch, double touch>>). Also, the restrictions regarding the robot positions are lifted.
 
 Additional time is allowed for a penalty kick to be taken at the end of each half or at the end of periods of overtime.
 

--- a/chapters/refereecommands.adoc
+++ b/chapters/refereecommands.adoc
@@ -120,9 +120,10 @@ free kicks are used to restart the game after a <<Fouls, foul>> has occurred. Ad
 When the force start command is issued, the game is immediately resumed and both teams are allowed to approach and <<Ball Manipulation, manipulate the ball>> again.
 
 .Usage
-The referee can issue a stop command followed by force start if there is a clear lack of progress for at least 10 seconds while both teams are allowed to approach and <<Ball Manipulation, manipulate the ball>>.
+A neutral forced start is used in situations where no team is clearly in favor, such as:
 
-It can also be used to resume the game when the game had to be stopped and no team or both teams are at fault.
+* the game had to be stopped without a specific reason.
+* both teams are at fault.
 
 ==== Penalty Kick
 .Definition

--- a/chapters/refereecommands.adoc
+++ b/chapters/refereecommands.adoc
@@ -157,6 +157,20 @@ Additional time is allowed for a penalty kick to be taken at the end of each hal
 Penalty Kicks are used to punish teams that received multiple <<Yellow Card, yellow cards>>, as well as to punish <<Unsporting Behavior, unsporting behavior>> and <<Multiple Defenders, multiple defenders>>.
 
 
+=== Ball In And Out Of Play
+When the match is <<Stopping The Game, stopped>>, the ball is considered *out of play* until it has been brought into play.
+
+When the match is <<Resuming The Game, resumed>>, the ball is considered *in play* until the next stoppage occurs.
+The match is resumed when
+
+* <<Force Start, force start>> has been issued.
+* the ball moved at least 0.05 meters following a <<Kick-Off, kick-off>>, <<Free Kick, free kick>> or <<Penalty Kick, penalty kick>>.
+* 10 seconds passed following a <<Kick-Off, kick-off>>.
+* 5 seconds (Division A) or 10 seconds (Division B) passed following a <<Free Kick, free kick>>.
+
+NOTE: see <<Double Touch, double touch>> for the rationale of the 0.05 meter distance
+
+
 === Sanctions
 
 ==== Yellow Card

--- a/chapters/scoringgoals.adoc
+++ b/chapters/scoringgoals.adoc
@@ -4,6 +4,7 @@ A goal is scored if the ball enters the goal between the goal posts, provided th
 Additionally, the goal is only valid if
 
 * The height of the ball did not exceed 0.15 meters after the last touch of an attacker
+* The scoring team does not have an active <<No Stop Fouls, no goal timer>>
 
 NOTE: During <<Penalty Kick, penalty kicks>>, these additional rules do not apply.
 

--- a/chapters/scoringgoals.adoc
+++ b/chapters/scoringgoals.adoc
@@ -4,7 +4,7 @@ A goal is scored if the ball enters the goal between the goal posts, provided th
 Additionally, the goal is only valid if
 
 * The height of the ball did not exceed 0.15 meters after the last touch of an attacker
-* The scoring team does not have an active <<No Stop Fouls, no goal timer>>
+* The scoring team does not have an active <<Non Stopping Fouls, no goal timer>>
 
 NOTE: During <<Penalty Kick, penalty kicks>>, these additional rules do not apply.
 

--- a/chapters/scoringgoals.adoc
+++ b/chapters/scoringgoals.adoc
@@ -7,6 +7,6 @@ Additionally, the goal is only valid if
 * The ball was not located in the opponent defense area when the goal kick started.
 * The ball did not exceed the ball speed limit during the goal kick.
 
-NOTE: During <<Penalty Kick, penalty kicks>>, these additional rules do not apply.
+NOTE: During <<Penalty Kick, penalty kicks>>, more specific rules apply.
 
 If the goal is considered invalid, the game will be continued as if the ball crossed the goal line outside the goal.

--- a/chapters/scoringgoals.adoc
+++ b/chapters/scoringgoals.adoc
@@ -3,8 +3,9 @@ A goal is scored if the ball enters the goal between the goal posts, provided th
 
 Additionally, the goal is only valid if
 
-* The height of the ball did not exceed 0.15 meters after the last touch of an attacker
-* The scoring team does not have an active <<Non Stopping Fouls, no goal timer>>
+* The height of the ball did not exceed 0.15 meters after the last touch of an attacker.
+* The ball was not located in the opponent defense area when the goal kick started.
+* The ball did not exceed the ball speed limit during the goal kick.
 
 NOTE: During <<Penalty Kick, penalty kicks>>, these additional rules do not apply.
 

--- a/sslrules.adoc
+++ b/sslrules.adoc
@@ -3,6 +3,7 @@
 = Rules of the RoboCup Small Size League
 {docdate}
 :toc:
+:toclevels: 4
 
 // add icons from fontawesome in a up-to-date version
 ifdef::basebackend-html[]


### PR DESCRIPTION
- Reorganized rule violations into the following categories:
  - Offenses
  - Fouls
    - Stopping Fouls
    - No Stop Fouls
  - Ball Placement Violations
  - General Violations
- Removed advantage rule. Obsoleted by removal of stoppage to:
  - crashing
  - attacker touches robot in opponent defense area
- Added a No Goal Timer for each team
  - Every no stop foul adds 2 seconds to timer
  - Timer resets on:
    - Successful goal by opposing team
    - Half Time and overtime
- The following fouls have been changed to No Stop Fouls
  - Attacker In Defense Area
  - Excessive Dribbling
  - Ball Speed
  - Defender Too Close To Ball
  - Attacker Touches Robot In Opponent Defense Area
- Lack of progress timer changes
  - Decrease timeout for some situations in Div A

Feedback is specifically requested on:
- Any changes/issues with the categories.
- Should any of violations be in a different category?
- No goal timer
  - Some initial discussion on #25, #23, 
  - Is the time added for violations appropriate?
  - Should there be a timer cap?
- No Stop Foul grace period
  - Is the amount of time before triggering another no stop foul appropriate?

Other open foul pull requests will be closed in favor of this one as they will depend on the restructuring changes in this pull request.