### PR TITLE
Bugfix: Goals should be invalid, if bot committed foul

### DIFF
--- a/chapters/scoringgoals.adoc
+++ b/chapters/scoringgoals.adoc
@@ -4,7 +4,7 @@ provided that:
 
 * The team did not exceed the allowed number of robots when the ball entered the goal.
 * The height of the ball did not exceed 0.15 meters after the last touch of the teams robots.
-* The team did not commit any <<Non Stopping Fouls, non stopping foul>> since the teams robots last touched the ball.
+* The team did not commit any <<Non Stopping Fouls, non stopping foul>> in the last two seconds before the ball entered the goal.
 
 NOTE: "The team" refers to the scoring team that is awarded a goal, not the team that kicked the ball.
 For example, an own goal is not possible while the opponent team has too many robots on the field.


### PR DESCRIPTION
Right now, a bot could touch the ball inside the penalty area (committing non-stopping foul) and afterwards kick the ball into the goal. It would be valid, because the foul was before the robot last touched the ball. A 2-second timer will avoid this. 2 seconds is also the grace period for repeating a foul that is still being committed.

Respective change in the GC: https://github.com/RoboCup-SSL/ssl-game-controller/pull/23/files