### PR TITLE
fix broken internal cross reference

### DIFF
--- a/chapters/playingenvironment.adoc
+++ b/chapters/playingenvironment.adoc
@@ -111,7 +111,7 @@ It may also provide feedback information, like:
 - Number of robots currently allowed
 - Number of robots currently on the field
 
-The remote control may only be used by the <Robot Handler, robot handler>. There is always only one remote control per team, per match.
+The remote control may only be used by the <<Robot Handler, robot handler>>. There is always only one remote control per team, per match.
 
 The official implementation for the league can be found on GitHub: https://github.com/RoboCup-SSL/ssl-remote-control.
 


### PR DESCRIPTION
Due to a syntax error, an internal cross reference is unintentionally rendered as is.
![cross-reference for Robot Handler rendered as is](https://user-images.githubusercontent.com/33391846/167195553-d6b21039-96fe-4448-a779-b6d9d2810485.png)

This PR fixes it. 

This should have been done during the review period.. I'm sorry I'm late to notice. 