### PR TITLE
Bugfix: aimless kicks must cross the halfline, not the midline

### DIFF
--- a/chapters/ballleavesthefield.adoc
+++ b/chapters/ballleavesthefield.adoc
@@ -44,6 +44,6 @@ The ball has to be placed at the position from where the ball was kicked (see th
 After the ball has been placed, a <<Free Kick, free kick>> is awarded to the opponent of the team that last touched the ball before it left the field.
 
 .Usage
-A kick is aimless when after the ball touched a robot, it subsequently crossed the midline and then its opponent's goal line outside the goal without touching another robot.
+A kick is aimless when after the ball touched a robot, it subsequently crossed the halfline and then its opponent's goal line outside the goal without touching another robot.
 
 A kick-off kick cannot be aimless, as the ball is located at the midline and does therefore not cross it.


### PR DESCRIPTION
As discussed on the discord:

> I have a question about the aimless kick rule (6.2.3) in division B. Under Usage it states: "A kick is aimless when after the ball touched a robot, it subsequently crossed the midline and then its opponent’s goal line outside the goal without touching another robot." The midline is defined as the line parallel to the touch lines (the long borders of the field).
>
> Say a bot stood close to the defense area of the opponent, but slightly to the left of the midline. If that bot now shot at the goal, but missed it and the ball left the field to the right of the goal via the goalline, that would qualify as an aimless kick.
>
> Is this correct? Personally, I think the halfway line would be better suited for this definition.