### PR TITLE
Only count one foul per ball placement for interference

### DIFF
--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -158,6 +158,9 @@ If a robot of the non-placing team is too close to the line between
 the ball and the placement position for more than 2 seconds, it
 commits a foul. In this case, 10 seconds are added to the ball
 placement timer.
+Only one interference foul per ball placement phase counts towards the foul counter, but the placement timer is always incremented.
 
 NOTE: This rule does not cover all cases of ball placement interference.
 The <<Referee, referee>> is encouraged to call fouls if the non-placing team is obviously interfering with the ball placement.
+
+NOTE: If a robot keeps interfering the ball placement (for example if it is stuck or can not move), the human referee is encouraged to stop the placement and place the ball manually.


### PR DESCRIPTION
During RoboCup 2022, there were several situations where robots got stuck and kept interfering the placement, which resulted in a foul every 2 seconds, which quickly generated yellow and red cards.