### PR TITLE
Fix broken link to Game Event Table

### DIFF
--- a/chapters/playingenvironment.adoc
+++ b/chapters/playingenvironment.adoc
@@ -97,7 +97,7 @@ At least one automatic referee is required per game. If more than one automatic 
 
 New automatic referee implementations can be provided, given that the source code is open-sourced. New implementations must be announced at least three months before the competition. The <<Technical Committee, technical committee>> decides if an implementation will be used or not.
 
-The <<Game Event Table>> shows which game events an automatic referee implementation must be able to detect.
+The <<Game Events, Game Event Table>> shows which game events an automatic referee implementation must be able to detect.
 Individual game events can be disabled completely or in some automatic referee implementations if both teams and the <<Technical Committee, technical committee>> agree.
 
 Existing implementations can be found on Github: https://github.com/RoboCup-SSL/ssl-autorefs.


### PR DESCRIPTION
Section "Game Event Table" have been renamed to "Game Events" in commit 7adb143 (#64)