### PR TITLE
Limiting group phase DivA robots to 8

### DIFF
--- a/chapters/robots.adoc
+++ b/chapters/robots.adoc
@@ -3,7 +3,7 @@
 === Number Of Robots
 A match is played by two teams, with each team consisting of not more than 11 robots in division A and not more than 6 robots in division B, one of which may be the keeper. Each robot must be clearly numbered according to its vision pattern so that the referee can identify it during the match. The id of the keeper must be chosen before the match starts (see <<Choosing Keeper Id>>).
 
-To incentivize teams to move from division B to division A, during the division A group phase, matches will be played with a maximum of 8 robots. If both teams have more than 8 robots, they can play with up to 11 robots. In the division A knockout phase, teams can play with up to 11 robots.
+An exception is made during the Division A group phase, where the number of robots is limited to 8 if at least one of the two teams prefers it.
 
 === Hardware And Software Constraints
 The <<Referee, referee>> may force a team to remove a robot from the field if it does not satisfy the rules. Members of the <<Technical Committee, technical committee>> may also check the hardware and software constraints of robots at any point of the tournament.

--- a/chapters/robots.adoc
+++ b/chapters/robots.adoc
@@ -3,6 +3,8 @@
 === Number Of Robots
 A match is played by two teams, with each team consisting of not more than 11 robots in division A and not more than 6 robots in division B, one of which may be the keeper. Each robot must be clearly numbered according to its vision pattern so that the referee can identify it during the match. The id of the keeper must be chosen before the match starts (see <<Choosing Keeper Id>>).
 
+To incentivize teams to move from division B to division A, during the division A group phase, matches will be played with a maximum of 8 robots. If both teams have more than 8 robots, they can play with up to 11 robots. In the division A knockout phase, teams can play with up to 11 robots.
+
 === Hardware And Software Constraints
 The <<Referee, referee>> may force a team to remove a robot from the field if it does not satisfy the rules. Members of the <<Technical Committee, technical committee>> may also check the hardware and software constraints of robots at any point of the tournament.
 


### PR DESCRIPTION
As proposed during RoboCup 2023 and to help teams move from division B to division A. During the division A group phase, matches will be played with a maximum of 8 robots. In the Division A knockout phase, teams can play with up to 11 robots.