### PR TITLE
Added rule to 4.4.2 Timeouts

### DIFF
--- a/chapters/gamestructure.adoc
+++ b/chapters/gamestructure.adoc
@@ -150,7 +150,7 @@ NOTE: As a result, the time needed for a match is much greater than the playing 
 ==== Timeouts
 The <<Robot Handler, robot handler>> has to ask the referee for a timeout. Timeouts are handled like <<Overview, breaks>>, meaning that both teams are allowed to make modifications to their software and hardware (see <<Autonomy>>).
 
-Any robot that has been physically interacted with during a timeout must be treated as substituted, as outlined in <<Robot Substitution, Robot Substitution>>. Such a robot must be either removed from the field or placed in the area defined in <<Robot Substitution, Robot Substitution>> before the Timeout phase ends.
+Any robot that has been physically interacted with during a timeout must be taken out of the field. It can be brought in again, also during the same timeout, via the area outlined in <<Robot Substitution, Robot Substitution>>.
 
 Each team is allocated 4 timeouts at the beginning of the match. A total of 300 seconds is allowed for all timeouts. Timeouts may only be taken during a game
 stoppage. The time is monitored and recorded by the <<Game Controller Operator, game controller operator>>.

--- a/chapters/gamestructure.adoc
+++ b/chapters/gamestructure.adoc
@@ -150,7 +150,7 @@ NOTE: As a result, the time needed for a match is much greater than the playing 
 ==== Timeouts
 The <<Robot Handler, robot handler>> has to ask the referee for a timeout. Timeouts are handled like <<Overview, breaks>>, meaning that both teams are allowed to make modifications to their software and hardware (see <<Autonomy>>).
 
-Any robot that has been physically interacted with during a timeout must be treated as substituted, as outlined in <<Robot Substitution, Robot Substitution>>. Such a robot must be either removed from the field or placed in the area defined in <<Robot Substitution, Robot Substitution>> before the Timeout phase ends.
+Any robot that has been physically interacted with during a timeout must be treated as substituted, as outlined in <<Robot Substitution, Robot Substitution>>. Such a robot must be either removed from the field or placed in the area defined in <<Robot Substitution, Robot Substitution>> before the timeout phase ends.
 
 Each team is allocated 4 timeouts at the beginning of the match. A total of 300 seconds is allowed for all timeouts. Timeouts may only be taken during a game
 stoppage. The time is monitored and recorded by the <<Game Controller Operator, game controller operator>>.

--- a/chapters/gamestructure.adoc
+++ b/chapters/gamestructure.adoc
@@ -150,6 +150,8 @@ NOTE: As a result, the time needed for a match is much greater than the playing 
 ==== Timeouts
 The <<Robot Handler, robot handler>> has to ask the referee for a timeout. Timeouts are handled like <<Overview, breaks>>, meaning that both teams are allowed to make modifications to their software and hardware (see <<Autonomy>>).
 
+Any robot that has been physically interacted with during a timeout must be treated as substituted, as outlined in <<Robot Substitution, Robot Substitution>>. Such a robot must be either removed from the field or placed in the area defined in <<Robot Substitution, Robot Substitution>> before the Timeout phase ends.
+
 Each team is allocated 4 timeouts at the beginning of the match. A total of 300 seconds is allowed for all timeouts. Timeouts may only be taken during a game
 stoppage. The time is monitored and recorded by the <<Game Controller Operator, game controller operator>>.
 

--- a/chapters/robots.adoc
+++ b/chapters/robots.adoc
@@ -53,4 +53,4 @@ The type of wireless communication may also be restricted by the <<Local Organiz
 NOTE: Bluetooth is not allowed since it cannot be fixed to frequency channels.
 
 ==== Autonomy
-The robotic equipment has to be fully autonomous. Human operators are not permitted to enter any information to the system during a match, except in <<Overview, breaks>> or during a <<Timeouts,timeout>>. Disregarding this rule is considered <<Unsporting Behavior, unsporting behavior>>.
+The robotic equipment has to be fully autonomous. Human operators are not permitted to enter any information to the system during a match, except in <<Overview, breaks>> or during a <<Timeouts,timeout>>. Additionally, robots may not be manually moved during any phase of the match, except for moving robots out of the field, or into the field as described in <<Robot Substitution, Robot Substitution>>. Disregarding this rule is considered <<Unsporting Behavior, unsporting behavior>>.


### PR DESCRIPTION
This draft PR adds the following to section 4.4.2 Timeouts:
```
Any robot that has been physically interacted with during a timeout must be treated as substituted, as outlined in <<Robot Substitution, Robot Substitution>>. Such a robot must be either removed from the field or placed in the area defined in <<Robot Substitution, Robot Substitution>> before the Timeout phase ends.
```