### PR TITLE
Refactor robot hull color requirements for better clarity and flexibility

### DIFF
--- a/chapters/gamestructure.adoc
+++ b/chapters/gamestructure.adoc
@@ -97,7 +97,7 @@ The <<Referee, referee>> asks the <<Robot Handler, robot handlers>> of the teams
 However, if both teams prefer the same color, the referee assigns the colors by chance. In this case, the teams switch the colors after the first half of the match as well as after the first half of the overtime if applicable.
 
 ==== Choosing Robot Hull Colors
-Teams are encouraged to choose their preferred <<Hull Color of Robots, robot hull color>> (dark or bright) before the match. If both teams choose the same color, the <<Referee, referee>> assigns the colors by chance before the game starts. The selected hull color must be used throughout the game.
+Teams are encouraged to choose their preferred <<Color of Robots, robot hull color>> (dark or bright) before the match. If both teams choose the same color, the <<Referee, referee>> assigns the colors by chance before the game starts. The selected hull color must be used throughout the game.
 
 ==== Choosing Side And Kick-Off
 The <<Referee, referee>> tosses a coin with both <<Robot Handler, robot handlers>>. The winning team chooses the goal it will attack in the first half of the match. The other team takes the <<Kick-Off, kick-off>> to start the match.

--- a/chapters/robots.adoc
+++ b/chapters/robots.adoc
@@ -19,19 +19,21 @@ The <<Referee, referee>> has to force a team to remove a robot from the field if
 A robot must fit inside a 0.18 meters wide and 0.15 meters high cylinder at any point in time. Additionally, the top of the robot must adhere to the standard pattern size and surface constraints.
 
 ==== Hull Color of Robots
-To ensure clarity and effective identification during gameplay, the following rules apply to the coloring of robot hulls:
+To ensure clear identification and distinction during gameplay, robots must be visually distinguishable from the opposing team. The following rules apply to robot hull coloring:
 
-Bright and dark color scheme:
+Color scheme requirements:
 
-* All robots from a team must have interchangeable hull colors: one bright and one dark.
-* These two colors must be the same for all robots in a team.
-* The color must vertically cover at least 6 cm of the robot's maximum height.
+* All robots from a team must have interchangeable hull colors: one bright and one dark color.
+* These two colors must be consistent across all robots on the same team.
+* The distinctive coloring must cover at least 60% of the robot's hull.
 
-Coverage requirements:
+Design and durability requirements:
 
-* The robot hull must not be reflective to avoid interfering with the vision system.
-* The robot hull must avoid colors close to the ones used at <<Vision Pattern, vision pattern>> and <<Ball, ball>>. 
-* Colors must adhere properly and remain durable to prevent dropping or peeling during the match. If the color cover drops, it will be penalized accordingly (see <<Tipping Over Or Dropping Parts>>).
+* Cut-outs for wheels and essential functional components are permitted and do not count against the coverage requirement.
+* Teams may use creative patterns that distinguish their robots from other teams.
+* The robot hull must not be reflective to avoid interference with the vision system.
+* The robot hull must avoid colors similar to those used in the <<Vision Pattern, vision pattern>> and <<Ball, ball>>.
+* Colors must be properly applied and remain durable throughout the match to prevent peeling or dropping. If color covering detaches during play, penalties will apply (see <<Tipping Over Or Dropping Parts>>).
 
 ==== Dribbling Device
 Dribbling devices that actively exert spin on the ball, which keep the ball in contact with the robot are permitted under certain conditions:

--- a/chapters/robots.adoc
+++ b/chapters/robots.adoc
@@ -18,22 +18,22 @@ The <<Referee, referee>> has to force a team to remove a robot from the field if
 ==== Shape
 A robot must fit inside a 0.18 meters wide and 0.15 meters high cylinder at any point in time. Additionally, the top of the robot must adhere to the standard pattern size and surface constraints.
 
-==== Hull Color of Robots
-To ensure clear identification and distinction during gameplay, robots must be visually distinguishable from the opposing team. The following rules apply to robot hull coloring:
+==== Color of Robots
+To ensure clear identification during gameplay, robots must be visually distinguishable from the opposing team. The following rules apply:
 
 Color scheme requirements:
 
-* All robots from a team must have interchangeable hull colors: one bright and one dark color.
+* Robots must have distinctive coloring covering at least 60% of the robot's side.
+* All robots from a team must have interchangeable colors: one bright and one dark.
 * These two colors must be consistent across all robots on the same team.
-* The distinctive coloring must cover at least 60% of the robot's hull.
 
 Design and durability requirements:
 
-* Cut-outs for wheels and essential functional components are permitted and do not count against the coverage requirement.
-* Teams may use creative patterns that distinguish their robots from other teams.
-* The robot hull must not be reflective to avoid interference with the vision system.
-* The robot hull must avoid colors similar to those used in the <<Vision Pattern, vision pattern>> and <<Ball, ball>>.
-* Colors must be properly applied and remain durable throughout the match to prevent peeling or dropping. If color covering detaches during play, penalties will apply (see <<Tipping Over Or Dropping Parts>>).
+* Cut-outs for wheels and essential functional components are permitted and do not count against coverage requirements.
+* Teams may use creative patterns to distinguish their robots from other teams.
+* Robot color must not be reflective and the top surface should be black to avoid vision system interference.
+* Robot sides must avoid colors similar to those used in the <<Vision Pattern, vision pattern>> and <<Ball, ball>>.
+* Colors must be properly applied and durable throughout the match to prevent peeling or detachment. If color covering detaches during play, penalties will apply (see <<Tipping Over Or Dropping Parts>>).
 
 ==== Dribbling Device
 Dribbling devices that actively exert spin on the ball, which keep the ball in contact with the robot are permitted under certain conditions:

--- a/chapters/robots.adoc
+++ b/chapters/robots.adoc
@@ -23,7 +23,7 @@ To ensure clear identification during gameplay, robots must be visually distingu
 
 Color scheme requirements:
 
-* Robots must have distinctive coloring covering at least 60% of the robot's side.
+* Robots must have distinctive coloring covering at least 50% of the robot's side.
 * All robots from a team must have interchangeable colors: one bright and one dark.
 * These two colors must be consistent across all robots on the same team.
 

--- a/chapters/robots.adoc
+++ b/chapters/robots.adoc
@@ -23,15 +23,15 @@ To ensure clear identification during gameplay, robots must be visually distingu
 
 Color scheme requirements:
 
-* Robots must have distinctive coloring covering at least 50% of the robot's side.
+* Robots must have distinctive coloring covering at least 20% of the robot's surrounding area (bottom and top surfaces do not count).
+* The color must be partially visible from all sides.
 * All robots from a team must have interchangeable colors: one bright and one dark.
 * These two colors must be consistent across all robots on the same team.
 
 Design and durability requirements:
 
-* Cut-outs for wheels and essential functional components are permitted and do not count against coverage requirements.
 * Teams may use creative patterns to distinguish their robots from other teams.
-* Robot color must not be reflective and the top surface should be black to avoid vision system interference.
+* Robot color must not be reflective, and the top surface should be black to avoid vision system interference.
 * Robot sides must avoid colors similar to those used in the <<Vision Pattern, vision pattern>> and <<Ball, ball>>.
 * Colors must be properly applied and durable throughout the match to prevent peeling or detachment. If color covering detaches during play, penalties will apply (see <<Tipping Over Or Dropping Parts>>).
 


### PR DESCRIPTION
Refactors the "Color of Robots" section to improve guidance while providing teams more design flexibility.

Key Changes:
- Explicitly clarified coverage requirements and cut-out permissions
- Added explicit permission for creative patterns
- Fixed coverage in % of Robot's surrouding, focusing on the robot's visual distinction no matter its size.