### PR TITLE
Rename Emergency Stop to Force Timeout

### DIFF
--- a/chapters/appendix.adoc
+++ b/chapters/appendix.adoc
@@ -133,7 +133,7 @@ NOTE: The information shown in this table here may be incomplete. Please read th
 || <<Scoring Goals, INVALID_GOAL>> | - | <<Stop>> -> <<Free Kick>> | no | game controller
 || <<Robot Substitution, BOT_SUBSTITUTION>> | during <<Stop>> | <<Halt>> (after next stoppage), then <<Stop>> | no | remote control
 || <<Challenge Flags, CHALLENGE_FLAG>> | always | - | no | remote control
-|| <<Emergency stop, EMERGENCY_STOP>> | always | <<Halt>> -> <<Timeouts, Timeout>> + <<Yellow Card>> | no | remote control
+|| <<Forced Timeout, EMERGENCY_STOP>> | always | <<Halt>> -> <<Timeouts, Timeout>> + <<Yellow Card>> | no | remote control
 
 6+| *Manual*
 || <<Scoring Goals, GOAL>> | - | <<Stop>> -> <<Kick-Off>> | no | human referee

--- a/chapters/forcedtimeout.adoc
+++ b/chapters/forcedtimeout.adoc
@@ -1,4 +1,4 @@
-== Emergency stop
+== Forced Timeout
 
 .Definition
 A team can ask to stop the game immediately after a grace period of 10 seconds or at the next stoppage, whichever happens first regardless of the current situation.
@@ -19,6 +19,6 @@ For these possibilities there are two methods to proceed the game:
 . For *3*, the game is continued like after a regular timeout.
 
 .Usage
-An emergency stop intent can be made using <<Communication Flags, communication flags>>.
+A forced timeout intent can be made using <<Communication Flags, communication flags>>.
 
 NOTE: The referee may stop the game earlier if there is no promising play in action.

--- a/chapters/forcedtimeout.adoc
+++ b/chapters/forcedtimeout.adoc
@@ -1,11 +1,11 @@
 == Forced Timeout
 
 .Definition
-A team can ask to stop the game immediately after a grace period of 10 seconds or at the next stoppage, whichever happens first regardless of the current situation.
+A team can ask to stop the game after a grace period of 10 seconds or at the next stoppage, whichever happens first regardless of the current situation.
 It will receive a yellow card for this and must take a timeout immediately.
 If the team is out of timeouts, it is still allowed to remove robots from the field, but can not use any remaining timeout time.
 
-NOTE: This rule is supposed to be used in extreme situations only, e.g. a software crash or when robots are damaging themselves significantly.
+NOTE: This rule is supposed to be used in extreme situations only, e.g. a software crash or when robots are damaging themselves significantly. If robots are failing to the extent they are endangering the participants, the referee should immediatley invoke Halt, and may choose to penalize the team for <<Unsafe Operations, unsafe operations>>.
 
 When the game is stopped due to this rule, there are three possibilities that may have happened:
 

--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -34,6 +34,9 @@ It is not allowed to damage or modify robots of other teams.
 ==== Damaging The Field Or The Ball
 It is not allowed to damage or modify the field or the ball.
 
+==== Unsafe Operations
+It is not allowed to have robot failures that endanger the participants or scpectators. Examples of unsafe operations include, but not limited to: high power or high velocity uncontrolled robot operation, electronics fire, high voltage or visible arc discharge.
+
 ==== Disrespect Procedures
 Not following defined procedures repetitively, like for example:
 

--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -35,7 +35,7 @@ It is not allowed to damage or modify robots of other teams.
 It is not allowed to damage or modify the field or the ball.
 
 ==== Unsafe Operations
-It is not allowed to have robot failures that endanger the participants or scpectators. Examples of unsafe operations include, but not limited to: high power or high velocity uncontrolled robot operation, electronics fire, high voltage or visible arc discharge.
+It is not allowed to have robot failures that endanger the participants or spectators. Examples of unsafe operations include, but are not limited to: high power or high velocity uncontrolled robot operation, electronics fire, high voltage or visible arc discharge.
 
 ==== Disrespect Procedures
 Not following defined procedures repetitively, like for example:

--- a/chapters/playingenvironment.adoc
+++ b/chapters/playingenvironment.adoc
@@ -112,11 +112,11 @@ Individual game events can be disabled completely or in some automatic referee i
 A remote control for each team can optionally be provided by the tournament organizers.
 It is a physical device that allows entering the following commands:
 
-- Raise a challenge flag
 - Request a timeout
+- Request a forced timeout
 - Request robot substitution
-- Request emergency stop
 - Change the keeper id
+- Raise a challenge flag
 
 It may also provide feedback information, like:
 
@@ -131,7 +131,7 @@ The official implementation for the league can be found on GitHub: https://githu
 === Communication Flags
 
 The communication flags are used to avoid gesturing and yelling with the <<Referee, referee>> during a match.
-These flags are responsible for communicating various intents, such as: <<Timeouts, timeouts>>, <<Emergency stop, emergency stops>>, <<Robot Substitution, manual robot substitution>> and <<Challenge Flags, challenges>>.
+These flags are responsible for communicating various intents, such as: <<Timeouts, timeouts>>, <<Forced Timeout, forced timeout>>, <<Robot Substitution, manual robot substitution>> and <<Challenge Flags, challenges>>.
 
 The <<Referee, referee>> or <<Game Controller Operator, game controller operator>> has to acknowledge the communication flag.
 Any gesturing and yelling will be considered <<Unsporting Behavior, unsporting behavior>>, punished by a <<Red Card, red card>> after the first warning.

--- a/sslrules.adoc
+++ b/sslrules.adoc
@@ -37,7 +37,7 @@ include::chapters/substitution.adoc[]
 
 include::chapters/shootout.adoc[]
 
-include::chapters/emergencystop.adoc[]
+include::chapters/forcedtimeout.adoc[]
 
 include::chapters/challengeflag.adoc[]
 


### PR DESCRIPTION
This sets the stage to rename "Emergency Stop" in the league rules and league software. The league discussed that the name "Emergency Stop" generally doesn't describe what the action does and has negative safety implications. 

The event has a 10 second delay and is intended for situations where robots have lost partially lost control or software crashes. These are not emergencies. Neither of these are resolved by a field level e-stop and would still require physical intervention by the team either with the robot or the laptop. Also, the 10 second delay is the exact opposite of the expected behavior of "emergency stop" which is that true emergencies should be addressed without delay.

The action is now named "Force Timeout" (verb) and produces a "Forced Timeout" (noun) game state.

Clarify rules under the "Halt" section, that unsafe behavior by robots (e.g. loss of control, fire, electronics failures like unintended arc emission from kickers) is handled at the discretion of the referee, who may immediately halt the game at any time. The referee may penalize teams for repeated robot behavior that makes him question or conclude safety has been compromised.

